### PR TITLE
Make venv to not use symlink but rather copy the binaries

### DIFF
--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -522,7 +522,7 @@ if [ -n "${USE_CONDA}" ]; then
   pyenv-exec conda create $QUIET $VERBOSE --name "${VIRTUALENV_PATH##*/}" --yes "${VIRTUALENV_OPTIONS[@]}" python || STATUS="$?"
 else
   if [ -n "${USE_M_VENV}" ]; then
-    pyenv-exec python -m venv $QUIET $VERBOSE "${VIRTUALENV_OPTIONS[@]}" "${VIRTUALENV_PATH}" || STATUS="$?"
+    pyenv-exec python -m venv --copies $QUIET $VERBOSE "${VIRTUALENV_OPTIONS[@]}" "${VIRTUALENV_PATH}" || STATUS="$?"
   else
     pyenv-exec virtualenv $QUIET $VERBOSE "${VIRTUALENV_OPTIONS[@]}" "${VIRTUALENV_PATH}" || STATUS="$?"
   fi

--- a/test/envs.bats
+++ b/test/envs.bats
@@ -33,7 +33,7 @@ unstub_pyenv() {
 
   assert_success
   assert_output <<OUT
-PYENV_VERSION=3.5.1 python -m venv ${PYENV_ROOT}/versions/3.5.1/envs/venv
+PYENV_VERSION=3.5.1 python -m venv --copies ${PYENV_ROOT}/versions/3.5.1/envs/venv
 PYENV_VERSION=3.5.1/envs/venv python -s -m ensurepip
 rehashed
 OUT

--- a/test/pip.bats
+++ b/test/pip.bats
@@ -34,7 +34,7 @@ unstub_pyenv() {
 
   assert_success
   assert_output <<OUT
-PYENV_VERSION=3.5.1 python -m venv ${PYENV_ROOT}/versions/3.5.1/envs/venv
+PYENV_VERSION=3.5.1 python -m venv --copies ${PYENV_ROOT}/versions/3.5.1/envs/venv
 PYENV_VERSION=3.5.1/envs/venv python -s -m ensurepip
 rehashed
 OUT
@@ -62,7 +62,7 @@ OUT
 
   assert_success
   assert_output <<OUT
-PYENV_VERSION=3.3.6 python -m venv ${PYENV_ROOT}/versions/3.3.6/envs/venv
+PYENV_VERSION=3.3.6 python -m venv --copies ${PYENV_ROOT}/versions/3.3.6/envs/venv
 Installing pip from https://bootstrap.pypa.io/get-pip.py...
 PYENV_VERSION=3.3.6/envs/venv python -s ${TMP}/pyenv/cache/get-pip.py
 rehashed

--- a/test/pyvenv.bats
+++ b/test/pyvenv.bats
@@ -34,7 +34,7 @@ unstub_pyenv() {
 
   assert_success
   assert_output <<OUT
-PYENV_VERSION=3.5.1 python -m venv ${PYENV_ROOT}/versions/3.5.1/envs/venv
+PYENV_VERSION=3.5.1 python -m venv --copies ${PYENV_ROOT}/versions/3.5.1/envs/venv
 rehashed
 OUT
 


### PR DESCRIPTION
Fixes https://github.com/yyuu/pyenv/issues/770 which in fact should have been opened in pyenv-virtualenv repo, not pyenv