### PR TITLE
Prefer 'set' over 'setenv' for fish shell

### DIFF
--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -146,8 +146,8 @@ if [ -z "$no_shell" ]; then
   case "$shell" in
   fish )
     cat <<EOS
-setenv PYENV_VERSION "${versions[*]}";
-setenv PYENV_ACTIVATE_SHELL 1;
+set -gx PYENV_VERSION "${versions[*]}";
+set -gx PYENV_ACTIVATE_SHELL 1;
 EOS
     ;;
   * )
@@ -164,8 +164,8 @@ fi
 case "${shell}" in
 fish )
   cat <<EOS
-setenv PYENV_VIRTUAL_ENV "${prefix}";
-setenv VIRTUAL_ENV "${prefix}";
+set -gx PYENV_VIRTUAL_ENV "${prefix}";
+set -gx VIRTUAL_ENV "${prefix}";
 EOS
   ;;
 * )
@@ -185,7 +185,7 @@ if [ -x "${prefix}/bin/conda" ]; then
   fi
   case "${shell}" in
   fish )
-    echo "setenv CONDA_DEFAULT_ENV \"${CONDA_DEFAULT_ENV}\";"
+    echo "set -gx CONDA_DEFAULT_ENV \"${CONDA_DEFAULT_ENV}\";"
     ;;
   * )
     echo "export CONDA_DEFAULT_ENV=\"${CONDA_DEFAULT_ENV}\";"
@@ -197,7 +197,7 @@ if [ -n "${PYTHONHOME}" ]; then
   case "${shell}" in
   fish )
     cat <<EOS
-setenv _OLD_VIRTUAL_PYTHONHOME "${PYTHONHOME}";
+set -gx _OLD_VIRTUAL_PYTHONHOME "${PYTHONHOME}";
 set -e PYTHONHOME;
 EOS
     ;;

--- a/bin/pyenv-sh-deactivate
+++ b/bin/pyenv-sh-deactivate
@@ -125,7 +125,7 @@ case "${shell}" in
 fish )
   cat <<EOS
 if [ -n "\$_OLD_VIRTUAL_PATH" ];
-  setenv PATH "\$_OLD_VIRTUAL_PATH";
+  set -gx PATH \$_OLD_VIRTUAL_PATH;
   set -e _OLD_VIRTUAL_PATH;
 end;
 EOS
@@ -144,7 +144,7 @@ case "${shell}" in
 fish )
   cat <<EOS
 if [ -n "\$_OLD_VIRTUAL_PYTHONHOME" ];
-  setenv PYTHONHOME "\$_OLD_VIRTUAL_PYTHONHOME";
+  set -gx PYTHONHOME "\$_OLD_VIRTUAL_PYTHONHOME";
   set -e _OLD_VIRTUAL_PYTHONHOME;
 end;
 EOS

--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -86,8 +86,8 @@ fi
 case "$shell" in
 fish )
   cat <<EOS
-setenv PATH '${PYENV_VIRTUALENV_ROOT:-${PYENV_VIRTUALENV_INSTALL_PREFIX}}/shims' \$PATH;
-setenv PYENV_VIRTUALENV_INIT 1;
+set -gx PATH '${PYENV_VIRTUALENV_ROOT:-${PYENV_VIRTUALENV_INSTALL_PREFIX}}/shims' \$PATH;
+set -gx PYENV_VIRTUALENV_INIT 1;
 EOS
   ;;
 * )


### PR DESCRIPTION
(See also
https://github.com/pyenv/pyenv/commit/be2e606fbdbd8d129563a73a588e33e4fe350665)

The setenv function in fish shell has changed dramatically in
fish-shell/fish-shell@75600b6
It now conforms to the csh version, which takes at most two arguments.
In these scripts, the form
    setenv PATH prepend_something $PATH
had been used, which had too many arguments.
Since setenv isn't a native command in fish, a suitable replacement
is to use the "set -gx" command, which can consume multiple arguments.