### PR TITLE
Set CONDA_PREFIX to make is useable in conda activate/deactivate scripts

### DIFF
--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -240,6 +240,8 @@ if [ -x "${prefix}/bin/conda" ]; then
     : # conda doesn't support fish
     ;;
   * )
+    CONDA_PREFIX="$prefix"
+    echo "export CONDA_PREFIX=\"${CONDA_PREFIX}\";"
     for script in "${prefix}/etc/conda/activate.d"/*.sh; do
       echo ". \"${script}\";"
     done

--- a/bin/pyenv-sh-deactivate
+++ b/bin/pyenv-sh-deactivate
@@ -69,6 +69,7 @@ if [ -x "${prefix}/bin/conda" ]; then
     for script in "${prefix}/etc/conda/deactivate.d"/*.sh; do
       echo ". \"${script}\";"
     done
+    echo "unset CONDA_PREFIX"
     ;;
   esac
   shopt -u nullglob

--- a/test/conda-activate.bats
+++ b/test/conda-activate.bats
@@ -39,6 +39,7 @@ export CONDA_DEFAULT_ENV="root";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
 export _OLD_VIRTUAL_PS1="\${PS1}";
 export PS1="(anaconda-2.3.0) \${PS1}";
+export CONDA_PREFIX="${TMP}/pyenv/versions/anaconda-2.3.0";
 EOS
 
   unstub pyenv-version-name
@@ -97,6 +98,7 @@ export CONDA_DEFAULT_ENV="root";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
 export _OLD_VIRTUAL_PS1="\${PS1}";
 export PS1="(miniconda-3.9.1) \${PS1}";
+export CONDA_PREFIX="${TMP}/pyenv/versions/miniconda-3.9.1";
 EOS
 
   unstub pyenv-virtualenv-prefix
@@ -126,6 +128,7 @@ export CONDA_DEFAULT_ENV="foo";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
 export _OLD_VIRTUAL_PS1="\${PS1}";
 export PS1="(anaconda-2.3.0/envs/foo) \${PS1}";
+export CONDA_PREFIX="${TMP}/pyenv/versions/anaconda-2.3.0/envs/foo";
 . "${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo/etc/conda/activate.d/activate.sh";
 EOS
 
@@ -158,6 +161,7 @@ export CONDA_DEFAULT_ENV="bar";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
 export _OLD_VIRTUAL_PS1="\${PS1}";
 export PS1="(miniconda-3.9.1/envs/bar) \${PS1}";
+export CONDA_PREFIX="${TMP}/pyenv/versions/miniconda-3.9.1/envs/bar";
 . "${PYENV_ROOT}/versions/miniconda-3.9.1/envs/bar/etc/conda/activate.d/activate.sh";
 EOS
 

--- a/test/conda-deactivate.bats
+++ b/test/conda-deactivate.bats
@@ -30,6 +30,7 @@ setup() {
 
   assert_success
   assert_output <<EOS
+unset CONDA_PREFIX
 unset PYENV_VIRTUAL_ENV;
 unset VIRTUAL_ENV;
 unset CONDA_DEFAULT_ENV;
@@ -97,6 +98,7 @@ EOS
   assert_success
   assert_output <<EOS
 . "${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo/etc/conda/deactivate.d/deactivate.sh";
+unset CONDA_PREFIX
 unset PYENV_VIRTUAL_ENV;
 unset VIRTUAL_ENV;
 unset CONDA_DEFAULT_ENV;


### PR DESCRIPTION
The `CONDA_PREFIX` environment variable is used in some activate/deactivate scripts. If it is not set they do not work correctly. One example is the [gdal package](https://github.com/conda-forge/libgdal-feedstock/blob/master/recipe/scripts/activate.sh). 

The `CONDA_PREFIX` variable is normally set in [activate](https://github.com/conda/conda/blob/301133cb8c804730c218ad8e47f116a8b1af51fc/conda/activate.py#L241) which is not used in pyenv.