### PR TITLE
Generate `pydoc` executable after creating new virtualenv

### DIFF
--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -533,6 +533,16 @@ if [ -d "${VIRTUALENV_PATH}" ] && [ -n "${COMPAT_VIRTUALENV_PATH}" ]; then
   ln -fs "${VIRTUALENV_PATH}" "${COMPAT_VIRTUALENV_PATH}"
 fi
 
+if [ ! -e "${VIRTUALENV_PATH}/bin/pydoc" ]; then
+  cat <<EOS > "${VIRTUALENV_PATH}/bin/pydoc"
+#!${VIRTUALENV_PATH}/bin/python
+import pydoc
+if __name__ == '__main__':
+      pydoc.cli()
+EOS
+  chmod +x "${VIRTUALENV_PATH}/bin/pydoc"
+fi
+
 if [ -z "${NO_ENSUREPIP}" ]; then
   ## Install setuptools and pip.
   PYENV_VERSION="${VIRTUALENV_NAME}" build_package_ensurepip

--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -534,6 +534,7 @@ if [ -d "${VIRTUALENV_PATH}" ] && [ -n "${COMPAT_VIRTUALENV_PATH}" ]; then
 fi
 
 if [ ! -e "${VIRTUALENV_PATH}/bin/pydoc" ]; then
+  mkdir -p "${VIRTUALENV_PATH}/bin"
   cat <<EOS > "${VIRTUALENV_PATH}/bin/pydoc"
 #!${VIRTUALENV_PATH}/bin/python
 import pydoc

--- a/test/pyvenv.bats
+++ b/test/pyvenv.bats
@@ -32,11 +32,12 @@ unstub_pyenv() {
 
   run pyenv-virtualenv venv
 
-  assert_success
   assert_output <<OUT
 PYENV_VERSION=3.5.1 python -m venv ${PYENV_ROOT}/versions/3.5.1/envs/venv
 rehashed
 OUT
+  assert [ -x "${PYENV_ROOT}/versions/3.5.1/envs/venv/bin/pydoc" ]
+  assert_success
 
   unstub_pyenv
   unstub pyenv-virtualenv-prefix
@@ -57,11 +58,12 @@ OUT
 
   run pyenv-virtualenv venv
 
-  assert_success
   assert_output <<OUT
 PYENV_VERSION=3.5.1 virtualenv ${PYENV_ROOT}/versions/3.5.1/envs/venv
 rehashed
 OUT
+  assert [ -x "${PYENV_ROOT}/versions/3.5.1/envs/venv/bin/pydoc" ]
+  assert_success
 
   unstub_pyenv
   unstub pyenv-virtualenv-prefix
@@ -69,7 +71,7 @@ OUT
   teardown_m_venv "3.5.1"
 }
 
-@test "install virtualenv if venv is not avaialble" {
+@test "install virtualenv if venv is not available" {
   export PYENV_VERSION="3.2.1"
   setup_version "3.2.1"
   stub_pyenv "${PYENV_VERSION}"
@@ -81,12 +83,13 @@ OUT
 
   run pyenv-virtualenv venv
 
-  assert_success
   assert_output <<OUT
 PYENV_VERSION=3.2.1 pip install virtualenv==13.1.2
 PYENV_VERSION=3.2.1 virtualenv ${PYENV_ROOT}/versions/3.2.1/envs/venv
 rehashed
 OUT
+  assert [ -x "${PYENV_ROOT}/versions/3.2.1/envs/venv/bin/pydoc" ]
+  assert_success
 
   unstub_pyenv
   unstub pyenv-virtualenv-prefix
@@ -112,6 +115,7 @@ PYENV_VERSION=3.5.1 pip install virtualenv
 PYENV_VERSION=3.5.1 virtualenv --python=${TMP}/python3 ${PYENV_ROOT}/versions/3.5.1/envs/venv
 rehashed
 OUT
+  assert [ -x "${PYENV_ROOT}/versions/3.5.1/envs/venv/bin/pydoc" ]
   assert_success
 
   unstub_pyenv
@@ -138,6 +142,7 @@ PYENV_VERSION=3.5.1 pip install virtualenv
 PYENV_VERSION=3.5.1 virtualenv --python=${TMP}/python3 ${PYENV_ROOT}/versions/3.5.1/envs/venv
 rehashed
 OUT
+  assert [ -x "${PYENV_ROOT}/versions/3.5.1/envs/venv/bin/pydoc" ]
   assert_success
 
   unstub_pyenv
@@ -158,12 +163,13 @@ OUT
 
   PIP_REQUIRE_VENV="true" run pyenv-virtualenv venv
 
-  assert_success
   assert_output <<OUT
 PIP_REQUIRE_VENV= PYENV_VERSION=3.2.1 pip install virtualenv==13.1.2
 PIP_REQUIRE_VENV= PYENV_VERSION=3.2.1 virtualenv ${PYENV_ROOT}/versions/3.2.1/envs/venv
 rehashed
 OUT
+  assert [ -x "${PYENV_ROOT}/versions/3.2.1/envs/venv/bin/pydoc" ]
+  assert_success
 
   unstub_pyenv
   unstub pyenv-virtualenv-prefix

--- a/test/virtualenv.bats
+++ b/test/virtualenv.bats
@@ -34,12 +34,13 @@ unstub_pyenv() {
 
   run pyenv-virtualenv "2.7.11" "venv"
 
-  assert_success
   assert_output <<OUT
 PYENV_VERSION=2.7.11 virtualenv ${PYENV_ROOT}/versions/2.7.11/envs/venv
 Installing pip from https://bootstrap.pypa.io/get-pip.py...
 rehashed
 OUT
+  assert [ -x "${PYENV_ROOT}/versions/2.7.11/envs/venv/bin/pydoc" ]
+  assert_success
 
   unstub_pyenv
   unstub pyenv-virtualenv-prefix
@@ -60,12 +61,13 @@ OUT
 
   run pyenv-virtualenv venv
 
-  assert_success
   assert_output <<OUT
 PYENV_VERSION=2.7.11 virtualenv ${PYENV_ROOT}/versions/2.7.11/envs/venv
 Installing pip from https://bootstrap.pypa.io/get-pip.py...
 rehashed
 OUT
+  assert [ -x "${PYENV_ROOT}/versions/2.7.11/envs/venv/bin/pydoc" ]
+  assert_success
 
   unstub_pyenv
   unstub pyenv-version-name
@@ -92,6 +94,7 @@ PYENV_VERSION=2.7.11 virtualenv --verbose --python=${TMP}/python ${PYENV_ROOT}/v
 Installing pip from https://bootstrap.pypa.io/get-pip.py...
 rehashed
 OUT
+  assert [ -x "${PYENV_ROOT}/versions/2.7.11/envs/venv/bin/pydoc" ]
   assert_success
 
   unstub_pyenv
@@ -119,6 +122,7 @@ PYENV_VERSION=2.7.11 virtualenv --verbose --python=${TMP}/python ${PYENV_ROOT}/v
 Installing pip from https://bootstrap.pypa.io/get-pip.py...
 rehashed
 OUT
+  assert [ -x "${PYENV_ROOT}/versions/2.7.11/envs/venv/bin/pydoc" ]
   assert_success
 
   unstub_pyenv
@@ -176,12 +180,13 @@ OUT
 
   run pyenv-virtualenv "2.7.11" "2.7.11/envs/foo"
 
-  assert_success
   assert_output <<OUT
 PYENV_VERSION=2.7.11 virtualenv ${PYENV_ROOT}/versions/2.7.11/envs/foo
 Installing pip from https://bootstrap.pypa.io/get-pip.py...
 rehashed
 OUT
+  assert [ -x "${PYENV_ROOT}/versions/2.7.11/envs/foo/bin/pydoc" ]
+  assert_success
 
   unstub_pyenv
   unstub pyenv-virtualenv-prefix


### PR DESCRIPTION
`virtualenv` will generate `pydoc` as a shell alias, not as an executable. Because pyenv's relying on shim script, there should be some executable to work it properly.

(fixes #197, pyenv/pyenv#963)