### PR TITLE
WORKAROUND: Force usage of pythonX.X for -m venv

### DIFF
--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -108,7 +108,7 @@ version() {
     echo "pyenv-virtualenv ${PYENV_VIRTUALENV_VERSION} (conda ${version:-unknown})"
   else
     if [ -n "$USE_M_VENV" ]; then
-      echo "pyenv-virtualenv ${PYENV_VIRTUALENV_VERSION} (python -m venv)"
+      echo "pyenv-virtualenv ${PYENV_VIRTUALENV_VERSION} (python${PYENV_VERSION:0:3} -m venv)"
     else
       version="$(pyenv-exec virtualenv --version 2>/dev/null || true)"
       echo "pyenv-virtualenv ${PYENV_VIRTUALENV_VERSION} (virtualenv ${version:-unknown})"
@@ -123,7 +123,7 @@ usage() {
     pyenv-exec conda create --help 2>/dev/null || true
   else
     if [ -n "${USE_M_VENV}" ]; then
-      pyenv-exec python -m venv --help 2>/dev/null || true
+      pyenv-exec python${PYENV_VERSION:0:3} -m venv --help 2>/dev/null || true
     else
       pyenv-exec virtualenv --help 2>/dev/null || true
     fi
@@ -141,7 +141,7 @@ detect_venv() {
     if [ -x "${prefix}/bin/virtualenv" ]; then
       HAS_VIRTUALENV=1
     fi
-    if pyenv-exec python -m venv --help 1>/dev/null 2>&1; then
+    if pyenv-exec python${PYENV_VERSION:0:3} -m venv --help 1>/dev/null 2>&1; then
       HAS_M_VENV=1
     fi
   fi
@@ -409,7 +409,7 @@ else
     unset QUIET
     unset VERBOSE
     if [ -n "${VIRTUALENV_PYTHON}" ]; then
-      echo "pyenv-virtualenv: \`--python=${VIRTUALENV_PYTHON}' is not supported by \`python -m venv'." 1>&2
+      echo "pyenv-virtualenv: \`--python=${VIRTUALENV_PYTHON}' is not supported by \`python${PYENV_VERSION:0:3} -m venv'." 1>&2
       exit 1
     fi
   else
@@ -524,7 +524,7 @@ if [ -n "${USE_CONDA}" ]; then
   pyenv-exec conda create $QUIET $VERBOSE --name "${VIRTUALENV_PATH##*/}" --yes "${VIRTUALENV_OPTIONS[@]}" python || STATUS="$?"
 else
   if [ -n "${USE_M_VENV}" ]; then
-    pyenv-exec python -m venv $QUIET $VERBOSE "${VIRTUALENV_OPTIONS[@]}" "${VIRTUALENV_PATH}" || STATUS="$?"
+    pyenv-exec python${PYENV_VERSION:0:3} -m venv $QUIET $VERBOSE "${VIRTUALENV_OPTIONS[@]}" "${VIRTUALENV_PATH}" || STATUS="$?"
   else
     pyenv-exec virtualenv $QUIET $VERBOSE "${VIRTUALENV_OPTIONS[@]}" "${VIRTUALENV_PATH}" || STATUS="$?"
   fi

--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -108,7 +108,7 @@ version() {
     echo "pyenv-virtualenv ${PYENV_VIRTUALENV_VERSION} (conda ${version:-unknown})"
   else
     if [ -n "$USE_M_VENV" ]; then
-      echo "pyenv-virtualenv ${PYENV_VIRTUALENV_VERSION} (python${PYENV_VERSION:0:3} -m venv)"
+      echo "pyenv-virtualenv ${PYENV_VIRTUALENV_VERSION} (python${PYENV_PYTHON_VERSION:0:3} -m venv)"
     else
       version="$(pyenv-exec virtualenv --version 2>/dev/null || true)"
       echo "pyenv-virtualenv ${PYENV_VIRTUALENV_VERSION} (virtualenv ${version:-unknown})"
@@ -123,7 +123,7 @@ usage() {
     pyenv-exec conda create --help 2>/dev/null || true
   else
     if [ -n "${USE_M_VENV}" ]; then
-      pyenv-exec python${PYENV_VERSION:0:3} -m venv --help 2>/dev/null || true
+      pyenv-exec python${PYENV_PYTHON_VERSION:0:3} -m venv --help 2>/dev/null || true
     else
       pyenv-exec virtualenv --help 2>/dev/null || true
     fi
@@ -141,7 +141,7 @@ detect_venv() {
     if [ -x "${prefix}/bin/virtualenv" ]; then
       HAS_VIRTUALENV=1
     fi
-    if pyenv-exec python${PYENV_VERSION:0:3} -m venv --help 1>/dev/null 2>&1; then
+    if pyenv-exec python -m venv --help 1>/dev/null 2>&1; then
       HAS_M_VENV=1
     fi
   fi
@@ -167,7 +167,7 @@ build_package_ez_setup() {
       http get "${EZ_SETUP_URL}"
     fi
   } 1> "${ez_setup}"
-  pyenv-exec python -s "${ez_setup}" ${EZ_SETUP_OPTS} 1>&2 || {
+  pyenv-exec python${PYENV_PYTHON_VERSION:0:3} -s "${ez_setup}" ${EZ_SETUP_OPTS} 1>&2 || {
     echo "error: failed to install setuptools via ez_setup.py" >&2
     return 1
   }
@@ -318,6 +318,9 @@ fi
 # Set VERSION_NAME as default version in this script
 export PYENV_VERSION="${VERSION_NAME}"
 
+# Get the Python version from the interpreter itself
+export PYENV_PYTHON_VERSION=$(python3 --version 2>&1 | awk '{ print $2 }')
+
 # Source version must exist before creating virtualenv.
 PREFIX="$(pyenv-prefix 2>/dev/null || true)"
 if [ ! -d "${PREFIX}" ]; then
@@ -409,7 +412,7 @@ else
     unset QUIET
     unset VERBOSE
     if [ -n "${VIRTUALENV_PYTHON}" ]; then
-      echo "pyenv-virtualenv: \`--python=${VIRTUALENV_PYTHON}' is not supported by \`python${PYENV_VERSION:0:3} -m venv'." 1>&2
+      echo "pyenv-virtualenv: \`--python=${VIRTUALENV_PYTHON}' is not supported by \`python -m venv'." 1>&2
       exit 1
     fi
   else
@@ -524,7 +527,7 @@ if [ -n "${USE_CONDA}" ]; then
   pyenv-exec conda create $QUIET $VERBOSE --name "${VIRTUALENV_PATH##*/}" --yes "${VIRTUALENV_OPTIONS[@]}" python || STATUS="$?"
 else
   if [ -n "${USE_M_VENV}" ]; then
-    pyenv-exec python${PYENV_VERSION:0:3} -m venv $QUIET $VERBOSE "${VIRTUALENV_OPTIONS[@]}" "${VIRTUALENV_PATH}" || STATUS="$?"
+    pyenv-exec python${PYENV_PYTHON_VERSION:0:3} -m venv $QUIET $VERBOSE "${VIRTUALENV_OPTIONS[@]}" "${VIRTUALENV_PATH}" || STATUS="$?"
   else
     pyenv-exec virtualenv $QUIET $VERBOSE "${VIRTUALENV_OPTIONS[@]}" "${VIRTUALENV_PATH}" || STATUS="$?"
   fi

--- a/test/envs.bats
+++ b/test/envs.bats
@@ -26,14 +26,14 @@ unstub_pyenv() {
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-virtualenv-prefix " : false"
   stub pyenv-exec "python -m venv --help : true"
-  stub pyenv-exec "python -m venv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";mkdir -p \${PYENV_ROOT}/versions/3.5.1/envs/venv/bin"
+  stub pyenv-exec "python${PYENV_PYTHON_VERSION:0:3} -m venv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";mkdir -p \${PYENV_ROOT}/versions/3.5.1/envs/venv/bin"
   stub pyenv-exec "python -s -m ensurepip : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";touch \${PYENV_ROOT}/versions/3.5.1/envs/venv/bin/pip"
 
   run pyenv-virtualenv venv
 
   assert_success
   assert_output <<OUT
-PYENV_VERSION=3.5.1 python -m venv ${PYENV_ROOT}/versions/3.5.1/envs/venv
+PYENV_VERSION=3.5.1 python${PYENV_PYTHON_VERSION:0:3} -m venv ${PYENV_ROOT}/versions/3.5.1/envs/venv
 PYENV_VERSION=3.5.1/envs/venv python -s -m ensurepip
 rehashed
 OUT

--- a/test/pip.bats
+++ b/test/pip.bats
@@ -27,14 +27,14 @@ unstub_pyenv() {
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-virtualenv-prefix " : false"
   stub pyenv-exec "python -m venv --help : true"
-  stub pyenv-exec "python -m venv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";mkdir -p \${PYENV_ROOT}/versions/3.5.1/envs/venv/bin"
+  stub pyenv-exec "python${PYENV_PYTHON_VERSION:0:3} -m venv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";mkdir -p \${PYENV_ROOT}/versions/3.5.1/envs/venv/bin"
   stub pyenv-exec "python -s -m ensurepip : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";touch \${PYENV_ROOT}/versions/3.5.1/envs/venv/bin/pip"
 
   run pyenv-virtualenv venv
 
   assert_success
   assert_output <<OUT
-PYENV_VERSION=3.5.1 python -m venv ${PYENV_ROOT}/versions/3.5.1/envs/venv
+PYENV_VERSION=3.5.1 python${PYENV_PYTHON_VERSION:0:3} -m venv ${PYENV_ROOT}/versions/3.5.1/envs/venv
 PYENV_VERSION=3.5.1/envs/venv python -s -m ensurepip
 rehashed
 OUT
@@ -53,7 +53,7 @@ OUT
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-virtualenv-prefix " : false"
   stub pyenv-exec "python -m venv --help : true"
-  stub pyenv-exec "python -m venv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";mkdir -p \${PYENV_ROOT}/versions/3.3.6/envs/venv/bin"
+  stub pyenv-exec "python${PYENV_PYTHON_VERSION:0:3} -m venv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";mkdir -p \${PYENV_ROOT}/versions/3.3.6/envs/venv/bin"
   stub pyenv-exec "python -s -m ensurepip : false"
   stub pyenv-exec "python -s */get-pip.py : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";touch \${PYENV_ROOT}/versions/3.3.6/envs/venv/bin/pip"
   stub curl true
@@ -62,7 +62,7 @@ OUT
 
   assert_success
   assert_output <<OUT
-PYENV_VERSION=3.3.6 python -m venv ${PYENV_ROOT}/versions/3.3.6/envs/venv
+PYENV_VERSION=3.3.6 python${PYENV_PYTHON_VERSION:0:3} -m venv ${PYENV_ROOT}/versions/3.3.6/envs/venv
 Installing pip from https://bootstrap.pypa.io/get-pip.py...
 PYENV_VERSION=3.3.6/envs/venv python -s ${TMP}/pyenv/cache/get-pip.py
 rehashed

--- a/test/pyvenv.bats
+++ b/test/pyvenv.bats
@@ -27,13 +27,13 @@ unstub_pyenv() {
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-virtualenv-prefix " : false"
   stub pyenv-exec "python -m venv --help : true"
-  stub pyenv-exec "python -m venv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
+  stub pyenv-exec "python${PYENV_PYTHON_VERSION:0:3} -m venv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : true"
 
   run pyenv-virtualenv venv
 
   assert_output <<OUT
-PYENV_VERSION=3.5.1 python -m venv ${PYENV_ROOT}/versions/3.5.1/envs/venv
+PYENV_VERSION=3.5.1 python${PYENV_PYTHON_VERSION:0:3} -m venv ${PYENV_ROOT}/versions/3.5.1/envs/venv
 rehashed
 OUT
   assert [ -x "${PYENV_ROOT}/versions/3.5.1/envs/venv/bin/pydoc" ]

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -5,6 +5,8 @@ PATH="$BATS_TEST_DIRNAME/../bin:$PATH"
 PATH="$TMP/bin:$PATH"
 export PATH
 
+export PYENV_PYTHON_VERSION=$(python3 --version | awk '{ print $2 }')
+
 teardown() {
   rm -fr "$TMP"/*
 }

--- a/test/version.bats
+++ b/test/version.bats
@@ -25,12 +25,12 @@ setup() {
 @test "display venv version" {
   setup_m_venv "3.4.1"
   stub pyenv-prefix "echo '${PYENV_ROOT}/versions/3.4.1'"
-  stub pyenv-exec "python -m venv --help : true"
+  stub pyenv-exec "python${PYENV_PYTHON_VERSION:0:3} -m venv --help : true"
 
   run pyenv-virtualenv --version
 
   assert_success
-  [[ "$output" == "pyenv-virtualenv "?.?.?" (python -m venv)" ]]
+  [[ "$output" == "pyenv-virtualenv "?.?.?" (python${PYENV_PYTHON_VERSION:0:3} -m venv)" ]]
 
   unstub pyenv-prefix
   teardown_m_venv "3.4.1"


### PR DESCRIPTION
Uses ${PYENV_VERSION:0:3} to force venv to correctly
make all of the necessary symlinks in the virtualenv's
bin directory.

Refer to issue #206 for details.