### PR TITLE
Ensure PROMPT_COMMAND is set, to work with set -u

### DIFF
--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -139,7 +139,7 @@ EOS
   case "$shell" in
   bash )
     cat <<EOS
-if ! [[ "\$PROMPT_COMMAND" =~ _pyenv_virtualenv_hook ]]; then
+if ! [[ "\${PROMPT_COMMAND:=}" =~ _pyenv_virtualenv_hook ]]; then
   PROMPT_COMMAND="_pyenv_virtualenv_hook;\$PROMPT_COMMAND";
 fi
 EOS

--- a/test/init.bats
+++ b/test/init.bats
@@ -61,7 +61,7 @@ _pyenv_virtualenv_hook() {
   fi
   return \$ret
 };
-if ! [[ "${PROMPT_COMMAND:=}" =~ _pyenv_virtualenv_hook ]]; then
+if ! [[ "\${PROMPT_COMMAND:=}" =~ _pyenv_virtualenv_hook ]]; then
   PROMPT_COMMAND="_pyenv_virtualenv_hook;\$PROMPT_COMMAND";
 fi
 EOS

--- a/test/init.bats
+++ b/test/init.bats
@@ -61,7 +61,7 @@ _pyenv_virtualenv_hook() {
   fi
   return \$ret
 };
-if ! [[ "\$PROMPT_COMMAND" =~ _pyenv_virtualenv_hook ]]; then
+if ! [[ "${PROMPT_COMMAND:=}" =~ _pyenv_virtualenv_hook ]]; then
   PROMPT_COMMAND="_pyenv_virtualenv_hook;\$PROMPT_COMMAND";
 fi
 EOS


### PR DESCRIPTION
This change makes sure `PROMPT_COMMAND` is defined before using it to avoid errors when running under `set -u`.