### PR TITLE
Source conda 4.4.4 shell files

### DIFF
--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -237,12 +237,19 @@ if [ -x "${prefix}/bin/conda" ]; then
   shopt -s nullglob
   case "${shell}" in
   fish )
-    : # conda doesn't support fish
+    # conda 4.4 and above
+    for script in "${prefix}/etc/fish/conf.d"/*.fish; do
+      echo "source \"${script}\";"
+    done
     ;;
   * )
     CONDA_PREFIX="$prefix"
     echo "export CONDA_PREFIX=\"${CONDA_PREFIX}\";"
     for script in "${prefix}/etc/conda/activate.d"/*.sh; do
+      echo ". \"${script}\";"
+    done
+    # conda 4.4 and above
+    for script in "${prefix}/etc/profile.d"/*.sh; do
       echo ". \"${script}\";"
     done
     ;;


### PR DESCRIPTION
Conda 4.4.4 (https://github.com/conda/conda/releases/tag/4.4.0) made some changes on how to set up conda in the shell. This commit addresses these.

This fixes some of the discussion in #178.

Note that this requires conda/conda#7004 to be merged first (at least for those of us who use fish).