### PR TITLE
Unset `PIP_VERSION` before invoking `get-pip.py` as a workaround for `invalid truth value` error

### DIFF
--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -451,9 +451,12 @@ unset VIRTUALENV_VERSION
 # Download specified version of ez_setup.py/get-pip.py.
 if [ -n "${SETUPTOOLS_VERSION}" ]; then
   EZ_SETUP_URL="https://bitbucket.org/pypa/setuptools/raw/${SETUPTOOLS_VERSION}/ez_setup.py"
+  unset SETUPTOOLS_VERSION
 fi
 if [ -n "${PIP_VERSION}" ]; then
   GET_PIP_URL="https://raw.githubusercontent.com/pypa/pip/${PIP_VERSION}/contrib/get-pip.py"
+  # Unset `PIP_VERSION` from environment before invoking `get-pip.py` to deal with "ValueError: invalid truth value" (pypa/pip#4528)
+  unset PIP_VERSION
 fi
 
 


### PR DESCRIPTION
cf. pyenv/pyenv-installer#70 https://github.com/pyenv/pyenv/pull/1124