### PR TITLE
Remove shebang lines from bin/ scripts for performance

### DIFF
--- a/bin/pyenv-activate
+++ b/bin/pyenv-activate
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-#
 # Summary: Activate virtual environment
 #
 # Usage: pyenv activate <virtualenv>

--- a/bin/pyenv-deactivate
+++ b/bin/pyenv-deactivate
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-#
 # Summary: Deactivate virtual environment
 #
 # Usage: pyenv deactivate

--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-#
 # Summary: Activate virtual environment
 #
 # Usage: pyenv activate <virtualenv>

--- a/bin/pyenv-sh-deactivate
+++ b/bin/pyenv-sh-deactivate
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-#
 # Summary: Deactivate virtual environment
 #
 # Usage: pyenv deactivate

--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-#
 # Summary: Create a Python virtualenv using the pyenv-virtualenv plugin
 #
 # Usage: pyenv virtualenv [-f|--force] [VIRTUALENV_OPTIONS] [version] <virtualenv-name>

--- a/bin/pyenv-virtualenv-delete
+++ b/bin/pyenv-virtualenv-delete
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-#
 # Summary: Uninstall a specific Python virtualenv
 #
 # Usage: pyenv virtualenv-delete [-f|--force] <virtualenv>

--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Summary: Configure the shell environment for pyenv-virtualenv
 # Usage: eval "$(pyenv virtualenv-init - [<shell>])"
 #

--- a/bin/pyenv-virtualenv-prefix
+++ b/bin/pyenv-virtualenv-prefix
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-#
 # Summary: Display real_prefix for a Python virtualenv version
 # Usage: pyenv virtualenv-prefix [<virtualenv>]
 #

--- a/bin/pyenv-virtualenvs
+++ b/bin/pyenv-virtualenvs
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-#
 # Summary: List all Python virtualenvs found in `$PYENV_ROOT/versions/*'.
 # Usage: pyenv virtualenvs [--bare] [--skip-aliases]
 #


### PR DESCRIPTION
All scripts in bin/ are called through `pyenv` therefore the shebang
lines are not necessary. On some systems this provides a measurable
increase in performance of the shell prompt.

Fixes #259 

On my system this removes 400ms of run time from the `pyenv sh-activate` 
command.