### PR TITLE
bin/pyenv-virtualenv: pass PYENV_VERSION to pyenv-rehash

### DIFF
--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -585,10 +585,7 @@ fi
 # Execute `after_virtualenv` hooks.
 for hook in "${after_hooks[@]}"; do eval "$hook"; done
 
-# Run `pyenv-rehash` after a successful installation.
-if [ "$STATUS" == "0" ]; then
-  PYENV_VERSION="${VIRTUALENV_NAME}" pyenv-rehash
-else
+if [ "$STATUS" != "0" ]; then
   cleanup
 fi
 

--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -587,7 +587,7 @@ for hook in "${after_hooks[@]}"; do eval "$hook"; done
 
 # Run `pyenv-rehash` after a successful installation.
 if [ "$STATUS" == "0" ]; then
-  pyenv-rehash
+  PYENV_VERSION="${VIRTUALENV_NAME}" pyenv-rehash
 else
   cleanup
 fi

--- a/bin/pyenv-virtualenv-delete
+++ b/bin/pyenv-virtualenv-delete
@@ -100,5 +100,4 @@ if [ -d "$PREFIX" ]; then
   if [ -L "$COMPAT_PREFIX" ]; then
     rm -rf "$COMPAT_PREFIX"
   fi
-  pyenv-rehash
 fi


### PR DESCRIPTION
Required with https://github.com/pyenv/pyenv/pull/1185.

Also should run (the new) rehashing when activating a virtualenv directly (not using the chpwd hook).