### PR TITLE
Fix: support newer conda

### DIFF
--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -177,7 +177,8 @@ EOS
 esac
 
 # anaconda/miniconda
-if [ -x "${prefix}/bin/conda" ]; then
+if [ -d "${prefix}/conda-meta" ] ||
+     [ -x "${prefix}/bin/conda" ]; then
   if [[ "${prefix}" != "${prefix%/envs/*}" ]]; then
     CONDA_DEFAULT_ENV="${venv##*/envs/}"
   else
@@ -233,7 +234,8 @@ EOS
 fi
 
 # conda package anaconda/miniconda scripts (#173)
-if [ -x "${prefix}/bin/conda" ]; then
+if [ -d "${prefix}/conda-meta" ] ||
+     [ -x "${prefix}/bin/conda" ]; then
   shopt -s nullglob
   case "${shell}" in
   fish )

--- a/bin/pyenv-sh-deactivate
+++ b/bin/pyenv-sh-deactivate
@@ -59,7 +59,8 @@ if [ -n "$PYENV_VIRTUALENV_VERBOSE_ACTIVATE" ]; then
 fi
 
 # conda package anaconda/miniconda scripts (#173)
-if [ -x "${prefix}/bin/conda" ]; then
+if [ -d "${prefix}/conda-meta" ] ||
+     [ -x "${prefix}/bin/conda" ]; then
   shopt -s nullglob
   case "${shell}" in
   fish )

--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -537,10 +537,11 @@ for hook in "${before_hooks[@]}"; do eval "$hook"; done
 
 # Plan cleanup on unsuccessful installation.
 cleanup() {
+  [[ -L "${COMPAT_VIRTUALENV_PATH}" ]] && rm "${COMPAT_VIRTUALENV_PATH}"
   [ -z "${PREFIX_EXISTS}" ] && rm -rf "$VIRTUALENV_PATH"
 }
 
-trap cleanup SIGINT
+trap cleanup SIGINT ERR
 
 # Invoke virtualenv and record exit status in $STATUS.
 STATUS=0

--- a/bin/pyenv-virtualenv-prefix
+++ b/bin/pyenv-virtualenv-prefix
@@ -6,6 +6,7 @@
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
+. "${BASH_SOURCE%/*}"/../libexec/pyenv-virtualenv-realpath
 
 if [ -z "$PYENV_ROOT" ]; then
   PYENV_ROOT="${HOME}/.pyenv"
@@ -18,6 +19,15 @@ if [ -n "$1" ]; then
 else
   IFS=: versions=($(pyenv-version-name))
 fi
+
+append_virtualenv_prefix() {
+  if [ -d "${VIRTUALENV_PREFIX_PATH}" ]; then
+    VIRTUALENV_PREFIX_PATHS=("${VIRTUALENV_PREFIX_PATHS[@]}" "${VIRTUALENV_PREFIX_PATH:-${PYENV_PREFIX_PATH}}")
+  else
+    echo "pyenv-virtualenv: version \`${version}' is not a virtualenv" 1>&2
+    exit 1
+  fi
+}
 
 VIRTUALENV_PREFIX_PATHS=()
 for version in "${versions[@]}"; do
@@ -55,12 +65,11 @@ for version in "${versions[@]}"; do
           fi
         fi
       fi
-      if [ -d "${VIRTUALENV_PREFIX_PATH}" ]; then
-        VIRTUALENV_PREFIX_PATHS=("${VIRTUALENV_PREFIX_PATHS[@]}" "${VIRTUALENV_PREFIX_PATH:-${PYENV_PREFIX_PATH}}")
-      else
-        echo "pyenv-virtualenv: version \`${version}' is not a virtualenv" 1>&2
-        exit 1
-      fi
+      append_virtualenv_prefix
+    elif [ -d "${PYENV_PREFIX_PATH}/conda-meta" ]; then
+      # conda
+      VIRTUALENV_PREFIX_PATH="$(realpath "${PYENV_PREFIX_PATH}"/../..)"
+      append_virtualenv_prefix
     else
       echo "pyenv-virtualenv: version \`${version}' is not a virtualenv" 1>&2
       exit 1

--- a/bin/pyenv-virtualenvs
+++ b/bin/pyenv-virtualenvs
@@ -7,6 +7,7 @@
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
+. "${BASH_SOURCE%/*}"/../libexec/pyenv-virtualenv-realpath
 
 if [ -z "$PYENV_ROOT" ]; then
   PYENV_ROOT="${HOME}/.pyenv"
@@ -31,38 +32,6 @@ for arg; do
 done
 
 versions_dir="${PYENV_ROOT}/versions"
-
-if ! enable -f "${BASH_SOURCE%/*}"/../libexec/pyenv-realpath.dylib realpath 2>/dev/null; then
-  if [ -n "$PYENV_NATIVE_EXT" ]; then
-    echo "pyenv: failed to load \`realpath' builtin" >&2
-    exit 1
-  fi
-
-  READLINK=$(type -p greadlink readlink | head -1)
-  if [ -z "$READLINK" ]; then
-    echo "pyenv: cannot find readlink - are you missing GNU coreutils?" >&2
-    exit 1
-  fi
-
-  resolve_link() {
-    $READLINK "$1"
-  }
-
-  realpath() {
-    local cwd="$PWD"
-    local path="$1"
-    local name
-
-    while [ -n "$path" ]; do
-      name="${path##*/}"
-      [ "$name" = "$path" ] || cd "${path%/*}"
-      path="$(resolve_link "$name" || true)"
-    done
-
-    echo "${PWD}/$name"
-    cd "$cwd"
-  }
-fi
 
 if [ -d "$versions_dir" ]; then
   versions_dir="$(realpath "$versions_dir")"

--- a/etc/pyenv.d/which/conda.bash
+++ b/etc/pyenv.d/which/conda.bash
@@ -1,0 +1,11 @@
+# newer versions of conda share programs from the real prefix
+# this hook tries to find the executable there
+
+if [ ! -x "${PYENV_COMMAND_PATH}" ] && [[ "${PYENV_COMMAND_PATH##*/}" == "conda" ]]; then
+  if [ -d "${PYENV_ROOT}/versions/${version}/conda-meta" ]; then
+    conda_command_path="$(pyenv-virtualenv-prefix "$version")"/bin/"${PYENV_COMMAND_PATH##*/}"
+    if [ -x "${conda_command_path}" ]; then
+      PYENV_COMMAND_PATH="${conda_command_path}"
+    fi
+  fi
+fi

--- a/libexec/pyenv-virtualenv-realpath
+++ b/libexec/pyenv-virtualenv-realpath
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Summary: Substitute realpath if unavailable as a builtin or file
+# Usage: . pyenv-virtualenv-realpath
+
+if ! {
+    enable -f "${BASH_SOURCE%/*}"/../libexec/pyenv-realpath.dylib realpath ||
+      type realpath
+  } >/dev/null 2>&1; then
+  if [ -n "$PYENV_NATIVE_EXT" ]; then
+    echo "pyenv: failed to load \`realpath' builtin" >&2
+    exit 1
+  fi
+
+  READLINK=$(type -p greadlink readlink | head -1)
+  if [ -z "$READLINK" ]; then
+    echo "pyenv: cannot find readlink - are you missing GNU coreutils?" >&2
+    exit 1
+  fi
+
+  resolve_link() {
+    $READLINK "$1"
+  }
+
+  realpath() {
+    local f="$*" \
+          name dir
+    [[ $f ]] || {
+      >&2 echo ${FUNCNAME[0]}: missing operand
+      return
+    }
+    while [[ -L $f ]]; do
+      f="$(resolve_link "$f")"
+    done
+    if [[ ! -d $f ]]; then
+      name="/${f##*/}"
+      # parent?
+      dir="${f%/*}"
+      if [[ $dir == $f ]]; then
+        #lacks /: parent is current directory
+        f="$PWD"
+      else
+        f="$dir"
+      fi
+    fi
+    #absolute directory
+    dir="$(cd "$f"
+           pwd)"
+    echo "$dir$name"
+  }
+fi


### PR DESCRIPTION
pyenv-virtualenv had issues listing conda environments, activating conda environments, and cleaning up `pyenv virtualenv` runs on error.
The issue is primarily explained in #178: `conda` and `activate` files no longer exist under derived conda environment `bin` directories, so `pyenv-virtualenv` can't use them to detect conda.
To resolve this, I add criteria to detect a `conda-meta` subdirectory.
Obtaining `VIRTUALENV_PREFIX_PATH` uses an implementation of `realpath` that would normalize paths across multiple scripts (though this might also be achieved with `cd` in a subshell).
(Moreover, I'm puzzled that substitutes for `readlink` and related commands are redefined throughout several scripts instead of defined in a single file for inclusion via `source`ing. Is there a reason for this?)
A `pyenv-which` hook redirects `conda` invocations to its new location in the base environment.
Is this the best way to go about it?

I'd like to include functional tests, though I'm not sure how to best do that.
I welcome suggestions/solutions.

closes pyenv/pyenv#1230
closes #178
and probably others