### PR TITLE
Avoid VIRTUAL_ENV: parameter not set

### DIFF
--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -69,12 +69,12 @@ fi
 
 venv="${versions}"
 
-if [ -n "${VIRTUAL_ENV}" ]; then
+if [ -n "${VIRTUAL_ENV:-}" ]; then
   # exit as success if some virtualenv is already activated outside from pyenv-virtualenv
   if [ -z "${PYENV_VIRTUAL_ENV}" ]; then
     if [ -z "${FORCE}" ]; then
       if [ -z "${QUIET}" ]; then
-        echo "pyenv-virtualenv: virtualenv \`${VIRTUAL_ENV}' is already activated" 1>&2
+        echo "pyenv-virtualenv: virtualenv \`${VIRTUAL_ENV:-}' is already activated" 1>&2
       fi
       echo "true"
       exit 0
@@ -122,7 +122,7 @@ if [ -L "${prefix}" ]; then
 fi
 
 # exit as success if the virtualenv is already activated
-if [[ "${VIRTUAL_ENV}" == "${prefix}" ]]; then
+if [[ "${VIRTUAL_ENV:-}" == "${prefix}" ]]; then
   if [ -z "${FORCE}" ]; then
     if [ -z "${QUIET}" ]; then
       echo "pyenv-virtualenv: version \`${venv}' is already activated" 1>&2

--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -103,7 +103,7 @@ fish )
   cat <<EOS
 function _pyenv_virtualenv_hook --on-event fish_prompt;
   set -l ret \$status
-  if [ -n "\$VIRTUAL_ENV" ]
+  if [ -n "\${VIRTUAL_ENV:-}" ]
     pyenv activate --quiet; or pyenv deactivate --quiet; or true
   else
     pyenv activate --quiet; or true
@@ -127,7 +127,7 @@ esac
 if [[ "$shell" != "fish" ]]; then
   cat <<EOS
   local ret=\$?
-  if [ -n "\$VIRTUAL_ENV" ]; then
+  if [ -n "\${VIRTUAL_ENV:-}" ]; then
     eval "\$(pyenv sh-activate --quiet || pyenv sh-deactivate --quiet || true)" || true
   else
     eval "\$(pyenv sh-activate --quiet || true)" || true

--- a/test/init.bats
+++ b/test/init.bats
@@ -54,7 +54,7 @@ export PATH="${TMP}/pyenv/plugins/pyenv-virtualenv/shims:\${PATH}";
 export PYENV_VIRTUALENV_INIT=1;
 _pyenv_virtualenv_hook() {
   local ret=\$?
-  if [ -n "\$VIRTUAL_ENV" ]; then
+  if [ -n "\${VIRTUAL_ENV:-}" ]; then
     eval "\$(pyenv sh-activate --quiet || pyenv sh-deactivate --quiet || true)" || true
   else
     eval "\$(pyenv sh-activate --quiet || true)" || true
@@ -76,7 +76,7 @@ set -gx PATH '${TMP}/pyenv/plugins/pyenv-virtualenv/shims' \$PATH;
 set -gx PYENV_VIRTUALENV_INIT 1;
 function _pyenv_virtualenv_hook --on-event fish_prompt;
   set -l ret \$status
-  if [ -n "\$VIRTUAL_ENV" ]
+  if [ -n "\${VIRTUAL_ENV:-}" ]
     pyenv activate --quiet; or pyenv deactivate --quiet; or true
   else
     pyenv activate --quiet; or true
@@ -95,7 +95,7 @@ export PATH="${TMP}/pyenv/plugins/pyenv-virtualenv/shims:\${PATH}";
 export PYENV_VIRTUALENV_INIT=1;
 _pyenv_virtualenv_hook() {
   local ret=\$?
-  if [ -n "\$VIRTUAL_ENV" ]; then
+  if [ -n "\${VIRTUAL_ENV:-}" ]; then
     eval "\$(pyenv sh-activate --quiet || pyenv sh-deactivate --quiet || true)" || true
   else
     eval "\$(pyenv sh-activate --quiet || true)" || true


### PR DESCRIPTION
When shell runs with 'set -u' use of undefined variables triggers an
error like below:

_pyenv_virtualenv_hook:2: VIRTUAL_ENV: parameter not set
show_virtual_env:1: VIRTUAL_ENV: parameter not set

Using a default fallback value avoid such errors. Ideally we should
also update the testing to enable set -u on purpose so we can avoid
future regressions.

Whatever works with `set -u` will also work with `set +u` so there
is no need to add extra tests.