### PR TITLE
Use realpath of scripts to determine relative locations

### DIFF
--- a/bin/pyenv-virtualenv-prefix
+++ b/bin/pyenv-virtualenv-prefix
@@ -6,7 +6,21 @@
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
-. "${BASH_SOURCE%/*}"/../libexec/pyenv-virtualenv-realpath
+if [ -L "${BASH_SOURCE}" ]; then
+    READLINK=$(type -p greadlink readlink | head -1)
+    if [ -z "$READLINK" ]; then
+        echo "pyenv: cannot find readlink - are you missing GNU coreutils?" >&2
+        exit 1
+    fi
+    resolve_link() {
+        $READLINK -f "$1"
+    }
+    script_path=$(resolve_link ${BASH_SOURCE})
+else
+    script_path=${BASH_SOURCE}
+fi
+
+. ${script_path%/*}/../libexec/pyenv-virtualenv-realpath
 
 if [ -z "$PYENV_ROOT" ]; then
   PYENV_ROOT="${HOME}/.pyenv"

--- a/bin/pyenv-virtualenvs
+++ b/bin/pyenv-virtualenvs
@@ -7,7 +7,21 @@
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
-. "${BASH_SOURCE%/*}"/../libexec/pyenv-virtualenv-realpath
+if [ -L "${BASH_SOURCE}" ]; then
+    READLINK=$(type -p greadlink readlink | head -1)
+    if [ -z "$READLINK" ]; then
+        echo "pyenv: cannot find readlink - are you missing GNU coreutils?" >&2
+        exit 1
+    fi
+    resolve_link() {
+        $READLINK -f "$1"
+    }
+    script_path=$(resolve_link ${BASH_SOURCE})
+else
+    script_path=${BASH_SOURCE}
+fi
+
+. ${script_path%/*}/../libexec/pyenv-virtualenv-realpath
 
 if [ -z "$PYENV_ROOT" ]; then
   PYENV_ROOT="${HOME}/.pyenv"


### PR DESCRIPTION
Just using paths relative to `${BASH_SOURCE}` fails if the scripts are
symlinked to a location, as that variable reports the path at which
the script is invoked, not where it actually resides.  This commit
implements a simple version of the realpath functionality in order to
determine the path to the more comprehensive realpath script

This should resolve my issue #307 