### PR TITLE
set/unset CONDA_PREFIX on activate

### DIFF
--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -187,9 +187,11 @@ if [ -d "${prefix}/conda-meta" ] ||
   case "${shell}" in
   fish )
     echo "set -gx CONDA_DEFAULT_ENV \"${CONDA_DEFAULT_ENV}\";"
+    echo "set -gx CONDA_PREFIX \"${prefix}\";"
     ;;
   * )
     echo "export CONDA_DEFAULT_ENV=\"${CONDA_DEFAULT_ENV}\";"
+    echo "export CONDA_PREFIX=\"${prefix}\";"
     ;;
   esac
 fi

--- a/bin/pyenv-sh-deactivate
+++ b/bin/pyenv-sh-deactivate
@@ -64,7 +64,7 @@ if [ -d "${prefix}/conda-meta" ] ||
   shopt -s nullglob
   case "${shell}" in
   fish )
-    : # conda doesn't support fish
+      echo "set -e CONDA_PREFIX"
     ;;
   * )
     for script in "${prefix}/etc/conda/deactivate.d"/*.sh; do


### PR DESCRIPTION
Conda activate (at least in fish) appears to set both `CONDA_PREFIX` and `CONDA_DEFAULT_ENV`, and rely upon them both being set to determine the environment to use when none is specified. This patch sets `CONDA_PREFIX` appropriately, as well unsets in the fish case