### PR TITLE
List virtualenvs starting with a dot

### DIFF
--- a/bin/pyenv-virtualenvs
+++ b/bin/pyenv-virtualenvs
@@ -76,7 +76,7 @@ print_version() {
   num_versions=$((num_versions + 1))
 }
 
-shopt -s nullglob
+shopt -s dotglob nullglob
 for path in "$versions_dir"/*; do
   if [ -d "$path" ]; then
     if [ -n "$skip_aliases" ] && [ -L "$path" ]; then
@@ -96,7 +96,7 @@ for path in "$versions_dir"/*; do
     done
   fi
 done
-shopt -u nullglob
+shopt -u dotglob nullglob
 
 if [ "$num_versions" -eq 0 ] && [ -n "$include_system" ]; then
   echo "Warning: no Python virtualenv detected on the system" >&2

--- a/etc/pyenv.d/rehash/envs.bash
+++ b/etc/pyenv.d/rehash/envs.bash
@@ -1,10 +1,10 @@
 virtualenv_list_executable_names() {
   local file
-  shopt -s nullglob
+  shopt -s dotglob nullglob
   for file in "$PYENV_ROOT"/versions/*/envs/*/bin/*; do
     echo "${file##*/}"
   done
-  shopt -u nullglob
+  shopt -u dotglob nullglob
 }
 if declare -f make_shims 1>/dev/null 2>&1; then
   make_shims $(virtualenv_list_executable_names | sort -u)

--- a/etc/pyenv.d/uninstall/envs.bash
+++ b/etc/pyenv.d/uninstall/envs.bash
@@ -20,11 +20,11 @@ if [ -n "${DEFINITION}" ]; then
       fi
     else
       # Uninstall all virtualenvs inside `envs` directory too
-      shopt -s nullglob
+      shopt -s dotglob nullglob
       for virtualenv in "${PREFIX}/envs/"*; do
         pyenv-virtualenv-delete ${FORCE+-f} "${DEFINITION}/envs/${virtualenv##*/}"
       done
-      shopt -u nullglob
+      shopt -u dotglob nullglob
     fi
   fi
 fi


### PR DESCRIPTION
`pyenv-virtualenv` allows to create virtualenvs with names starting with a dot (e.g. `.dotfiles`), but those cannot be listed. This PR enables `dotglob` option when listing versions.