### PR TITLE
Return control to pyenv-uninstall in uninstall/envs.bash

### DIFF
--- a/etc/pyenv.d/uninstall/envs.bash
+++ b/etc/pyenv.d/uninstall/envs.bash
@@ -5,8 +5,7 @@ resolve_link() {
 if [ -n "${DEFINITION}" ]; then
   if [[ "${DEFINITION}" != "${DEFINITION%/envs/*}" ]]; then
     # Uninstall virtualenv by long name
-    exec pyenv-virtualenv-delete ${FORCE+-f} "${DEFINITION}"
-    exit 128
+    pyenv-virtualenv-delete ${FORCE+-f} "${DEFINITION}"
   else
     VERSION_NAME="${VERSION_NAME:-${DEFINITION##*/}}"
     PREFIX="${PREFIX:-${PYENV_ROOT}/versions/${VERSION_NAME}}"
@@ -15,8 +14,7 @@ if [ -n "${DEFINITION}" ]; then
       REAL_DEFINITION="${REAL_PREFIX#${PYENV_ROOT}/versions/}"
       if [[ "${REAL_DEFINITION}" != "${REAL_DEFINITION%/envs/*}" ]]; then
         # Uninstall virtualenv by short name
-        exec pyenv-virtualenv-delete ${FORCE+-f} "${REAL_DEFINITION}"
-        exit 128
+        pyenv-virtualenv-delete ${FORCE+-f} "${REAL_DEFINITION}"
       fi
     else
       # Uninstall all virtualenvs inside `envs` directory too
@@ -28,3 +26,4 @@ if [ -n "${DEFINITION}" ]; then
     fi
   fi
 fi
+FORCE=t


### PR DESCRIPTION
This would fix #320, since returning control to `pyenv-uninstall` would allow the rest of the `before_uninstall` and `after_install` hooks to run.

From my understanding, the `exec` would pass control to the other script and never return it, so it would never hit the `exit`.. and if it did, there's no real need to since they are in mutually exclusive `if` statements. However, I might be misunderstanding something here, or there might have been a reason it was done like that, so it's quite possible there's a problem with this solution that I'm not aware of.

One problem I noticed was the error when returning control to `pyenv-uninstall`. Setting `FORCE=t` avoids this error, although I'm not sure what exactly that does so I'm not sure if there's any issues with that.