### PR TITLE
detect & create conda environments

### DIFF
--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -139,7 +139,7 @@ detect_venv() {
   # Check the existence of executables as a workaround for the issue with pyenv-which-ext
   # https://github.com/yyuu/pyenv-virtualenv/issues/26
   local prefix="$(pyenv-prefix)"
-  if [ -x "${prefix}/bin/conda" ]; then
+  if [ -d "${prefix}/conda-meta" ] || [ -x "${prefix}/bin/conda" ]; then
     HAS_CONDA=1
   else
     if [ -x "${prefix}/bin/virtualenv" ]; then

--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -141,6 +141,9 @@ detect_venv() {
   local prefix="$(pyenv-prefix)"
   if [ -d "${prefix}/conda-meta" ] || [ -x "${prefix}/bin/conda" ]; then
     HAS_CONDA=1
+		if [ -d "${prefix}/envs" ]; then
+			IS_BASE_CONDA=1
+		fi
   else
     if [ -x "${prefix}/bin/virtualenv" ]; then
       HAS_VIRTUALENV=1
@@ -560,7 +563,11 @@ STATUS=0
 mkdir -p "${PYENV_VIRTUALENV_CACHE_PATH}"
 cd "${PYENV_VIRTUALENV_CACHE_PATH}"
 if [ -n "${USE_CONDA}" ]; then
-  pyenv-exec conda create $QUIET $VERBOSE --name "${VIRTUALENV_PATH##*/}" --yes "${VIRTUALENV_OPTIONS[@]}" python || STATUS="$?"
+  if [ -n "${IS_BASE_CONDA}" ]; then
+    pyenv-exec conda create $QUIET $VERBOSE --name "${VIRTUALENV_PATH##*/}" --yes "${VIRTUALENV_OPTIONS[@]}" python || STATUS="$?"
+  else
+    pyenv-exec conda create $QUIET $VERBOSE --clone "${VERSION_NAME##*/}" --name "${VIRTUALENV_PATH##*/}" --yes "${VIRTUALENV_OPTIONS[@]}" || STATUS="$?"
+  fi
 else
   if [ -n "${USE_M_VENV}" ]; then
     pyenv-exec "${M_VENV_PYTHON_BIN:-python}" -m venv $QUIET $VERBOSE "${VIRTUALENV_OPTIONS[@]}" "${VIRTUALENV_PATH}" || STATUS="$?"


### PR DESCRIPTION
`pyenv virtualenv` fails to create conda environments from conda environments.
```shellsession
$ pyenv virtualenv lsp test
Looking in links: /tmp/tmp0ao0gi5w
Requirement already satisfied: setuptools in /home/LOM0227/.pyenv/versions/miniconda3-latest/envs/test/lib/python3.7/site-packages (40.8.0)
Requirement already satisfied: pip in /home/LOM0227/.pyenv/versions/miniconda3-latest/envs/test/lib/python3.7/site-packages (19.0.3)
$ pyenv versions
* system (set by /home/LOM0227/.pyenv/version)
  lsp
  miniconda3-latest
  miniconda3-latest/envs/lsp
  miniconda3-latest/envs/test
  test
$ conda info -e
# conda environments:
#
base                  *  /home/LOM0227/.pyenv/versions/miniconda3-latest
lsp                      /home/LOM0227/.pyenv/versions/miniconda3-latest/envs/lsp
```

Instead, it attempts to make python venv environments.
These updates reuse logic from #290 to detect conda environments, detect conda base environments, and clone non-base environments supplied as version to `pyenv virtualenv`.