### PR TITLE
Stop delete force failing when virtualenv does not exist

### DIFF
--- a/bin/pyenv-virtualenv-delete
+++ b/bin/pyenv-virtualenv-delete
@@ -75,7 +75,7 @@ else
     if pyenv-virtualenv-prefix "${VERSION_NAME}" 1>/dev/null 2>&1; then
       PREFIX="${PYENV_ROOT}/versions/${VERSION_NAME}"
       unset COMPAT_PREFIX
-    else
+    elif [ -z "$FORCE" ]; then
       echo "pyenv-virtualenv: \`${DEFINITION}' is not a virtualenv." 1>&2
       exit 1
     fi


### PR DESCRIPTION
When `pyenv virtualenv-delete -f non-existent-virtualenv` is run then an error message is displayed and the return code is 1

This is contrary to the behavior described by `pyenv virtualenv-delete --help`:
```
Usage: pyenv virtualenv-delete [-f|--force] <virtualenv>

   -f  Attempt to remove the specified virtualenv without prompting
       for confirmation. If the virtualenv does not exist, do not
       display an error message.

See `pyenv virtualenvs` for a complete list of installed versions.
```

Specifically for the force flag: `If the virtualenv does not exist, do not display an error message.`

This PR addresses this by checking that the force flag is not set before continuing with standard behavior (displaying the error message and returning the non-zero code).