### PR TITLE
perf(sh-activate): avoid a pyenv-version-name call

### DIFF
--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -52,13 +52,18 @@ while [ $# -gt 0 ]; do
   shift 1
 done
 
+get_current_versions() {
+  local IFS=:
+  current_versions=($(pyenv-version-name 2>/dev/null))
+}
+
 no_shell=
 versions=("$@")
+current_versions=()
 if [ -z "${versions}" ]; then
   no_shell=1
-  OLDIFS="$IFS"
-  IFS=: versions=($(pyenv-version-name 2>/dev/null))
-  IFS="$OLDIFS"
+  get_current_versions
+  versions=("${current_versions[@]}")
 fi
 
 if [ -z "${PYENV_VIRTUALENV_INIT}" ]; then
@@ -84,9 +89,7 @@ fi
 
 if ! pyenv-virtualenv-prefix "${venv}" 1>/dev/null 2>&1; then
   # fallback to virtualenv of current version
-  OLDIFS="$IFS"
-  IFS=: current_versions=($(pyenv-version-name))
-  IFS="$OLDIFS"
+  [ -n "${current_versions}" ] || get_current_versions
   new_venv="${current_versions%/envs/*}/envs/${venv}"
   if pyenv-virtualenv-prefix "${new_venv}" 1>/dev/null 2>&1; then
     venv="${new_venv}"


### PR DESCRIPTION
Before:
```shellsession
$ hyperfine -i "pyenv sh-activate --quiet"
Benchmark #1: pyenv sh-activate --quiet
  Time (mean ± σ):      49.1 ms ±   3.0 ms    [User: 40.7 ms, System: 10.7 ms]
  Range (min … max):    45.4 ms …  59.0 ms    53 runs
```

After:
```shellsession
$ hyperfine -i "pyenv sh-activate --quiet"
Benchmark #1: pyenv sh-activate --quiet
  Time (mean ± σ):      39.5 ms ±   1.4 ms    [User: 31.4 ms, System: 9.7 ms]
  Range (min … max):    36.4 ms …  44.8 ms    70 runs
```