### PR TITLE
refactor: removed loop with cd to avoid problems returning to current pwd

### DIFF
--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -9,22 +9,11 @@
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
 
-resolve_link() {
-  $(type -p greadlink readlink | head -1) "$1"
-}
-
 abs_dirname() {
-  local cwd="$(pwd)"
   local path="$1"
-
-  while [ -n "$path" ]; do
-    cd "${path%/*}"
-    local name="${path##*/}"
-    path="$(resolve_link "$name" || true)"
-  done
-
-  pwd
-  cd "$cwd"
+  path="$(realpath $path)"
+  local abs_dirname="${path%/*}"
+  echo "${abs_dirname}"
 }
 
 PYENV_VIRTUALENV_INSTALL_PREFIX="$(dirname "$(abs_dirname "$0")")"


### PR DESCRIPTION
This MRs is just a fix that I applied in my local, maybe it can be useful to others, then I'm opening this PR.

Example of error got in terminal:
  ~/.pyenv/plugins/pyenv-virtualenv/bin/pyenv-virtualenv-init: linha 27: cd: /home/otheruser: Permission denied

More about the problem:
I've created a new user in my machine in linux, then I configured pyenv in the file `~/.bashrc`:
```sh
# Python (pyenv)
export PYENV_DIR="${HOME}/.pyenv"
eval "$(pyenv init -)"
eval "$(pyenv virtualenv-init -)"
```
On my old user folder `/home/olduser`, when I run:
```sh
su newuser
```
After put the password I get the error:
  /home/newuser/.pyenv/plugins/pyenv-virtualenv/bin/pyenv-virtualenv-init: linha 27: cd: /home/olduser: Permission denied
  
  Then this MR resolves the problem using realpath.