### PR TITLE
Check for executable file

### DIFF
--- a/etc/pyenv.d/which/conda.bash
+++ b/etc/pyenv.d/which/conda.bash
@@ -4,7 +4,7 @@
 if [ ! -x "${PYENV_COMMAND_PATH}" ] && [[ "${PYENV_COMMAND_PATH##*/}" == "conda" ]]; then
   if [ -d "${PYENV_ROOT}/versions/${version}/conda-meta" ]; then
     conda_command_path="$(pyenv-virtualenv-prefix "$version")"/bin/"${PYENV_COMMAND_PATH##*/}"
-    if [ -x "${conda_command_path}" ]; then
+    if [[ -f "${conda_command_path}" && -x "${conda_command_path}" ]]; then
       PYENV_COMMAND_PATH="${conda_command_path}"
     fi
   fi

--- a/etc/pyenv.d/which/python-config.bash
+++ b/etc/pyenv.d/which/python-config.bash
@@ -35,7 +35,7 @@ if [ ! -x "${PYENV_COMMAND_PATH}" ] && [[ "${PYENV_COMMAND_PATH##*/}" == "python
         fi
       fi
       virtualenv_command_path="${virtualenv_prefix}/bin/${PYENV_COMMAND_PATH##*/}"
-      if [ -x "${virtualenv_command_path}" ]; then
+      if [[ -f "${virtualenv_command_path}" && -x "${virtualenv_command_path}" ]]; then
         PYENV_COMMAND_PATH="${virtualenv_command_path}"
       fi
     fi

--- a/etc/pyenv.d/which/system-site-packages.bash
+++ b/etc/pyenv.d/which/system-site-packages.bash
@@ -45,7 +45,7 @@ if [ ! -x "${PYENV_COMMAND_PATH}" ]; then
       if [ -n "${include_system_site_packages}" ] && [ -n "${virtualenv_prefix}" ]; then
         # virtualenv is created with `--system-site-packages`
         virtualenv_command_path="${virtualenv_prefix}/bin/${PYENV_COMMAND_PATH##*/}"
-        if [ -x "${virtualenv_command_path}" ]; then
+        if [[ -f "${virtualenv_command_path}" && -x "${virtualenv_command_path}" ]]; then
           PYENV_COMMAND_PATH="${virtualenv_command_path}"
         fi
       fi


### PR DESCRIPTION
This PR adds additional checks on command path to ensure that PYENV_COMMAND_PATH is set only when it points to a command, not a directory. Since `${PYENV_COMMAND_PATH##*/}` can be empty, "which" can in certain condition pick up a `bin` directory instead of a command.