### PR TITLE
Fixes #394 - update pyenv virtualenvs to list virtualenvs start with dot prefixes

### DIFF
--- a/bin/pyenv-virtualenvs
+++ b/bin/pyenv-virtualenvs
@@ -76,6 +76,7 @@ print_version() {
   num_versions=$((num_versions + 1))
 }
 
+shopt -s dotglob
 shopt -s nullglob
 for path in "$versions_dir"/*; do
   if [ -d "$path" ]; then
@@ -96,6 +97,7 @@ for path in "$versions_dir"/*; do
     done
   fi
 done
+shopt -u dotglob
 shopt -u nullglob
 
 if [ "$num_versions" -eq 0 ] && [ -n "$include_system" ]; then


### PR DESCRIPTION
Fixes #394 
**After this small fix:**

1. `$ pyenv virtualenv 3.8.10 .my_virtualenv`
2. `$ pyenv virtualenvs --skip-aliases`
        `3.8.10/envs/.my_virtualenv (created from /opt/app-root/src/.pyenv/versions/3.8.10)`
