### PR TITLE
Fix get-pip.py URLs for older versions of Python

### DIFF
--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -479,7 +479,10 @@ if [ -z "${GET_PIP_URL}" ]; then
     # Use custom get-pip URL based on the target version (#1127)
     case "${PYENV_VERSION}" in
     2.6 | 2.6.* )
-      GET_PIP_URL="https://bootstrap.pypa.io/2.6/get-pip.py"
+      GET_PIP_URL="https://bootstrap.pypa.io/pip/2.6/get-pip.py"
+      ;;
+    2.7 | 2.7.* )
+      GET_PIP_URL="https://bootstrap.pypa.io/pip/2.7/get-pip.py"
       ;;
     3.2 | 3.2.* )
       GET_PIP_URL="https://bootstrap.pypa.io/3.2/get-pip.py"


### PR DESCRIPTION
This PR updates the get-pip.py URL for Python 2.6 and adds the URL for Python 2.7. 