### PR TITLE
Add (y/N) prompt help text

### DIFF
--- a/bin/pyenv-virtualenv-delete
+++ b/bin/pyenv-virtualenv-delete
@@ -88,7 +88,7 @@ if [ -z "$FORCE" ]; then
     exit 1
   fi
 
-  read -p "pyenv-virtualenv: remove $PREFIX? "
+  read -p "pyenv-virtualenv: remove $PREFIX? (y/N) "
   case "$REPLY" in
   y* | Y* ) ;;
   * ) exit 1 ;;


### PR DESCRIPTION
There is no example input like (y/N) or something so I often get confused if I just have to press enter or type y(or Y, yes, YES whatever)

So to be clear I added some help text just like other scripts

ex. [pyenv-install](https://github.com/pyenv/pyenv/blob/8b60418361e29d30fbe7ee3133e57f4d351464da/plugins/python-build/bin/pyenv-install#L160)