### PR TITLE
Semicolons missing for a working virtualenv-init

### DIFF
--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -126,13 +126,13 @@ esac
 
 if [[ "$shell" != "fish" ]]; then
   cat <<EOS
-  local ret=\$?
+  local ret=\$?;
   if [ -n "\$VIRTUAL_ENV" ]; then
-    eval "\$(pyenv sh-activate --quiet || pyenv sh-deactivate --quiet || true)" || true
+    eval "\$(pyenv sh-activate --quiet || pyenv sh-deactivate --quiet || true)" || true;
   else
-    eval "\$(pyenv sh-activate --quiet || true)" || true
-  fi
-  return \$ret
+    eval "\$(pyenv sh-activate --quiet || true)" || true;
+  fi;
+  return \$ret;
 };
 EOS
 


### PR DESCRIPTION
Since bash will replace all newlines with spaces from the output
when running:
  eval (pyenv virtualenv-init -)
the above line failed badly.