### PR TITLE
Fix another unbound variable error

### DIFF
--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -229,8 +229,8 @@ if [ -z "${PYENV_VIRTUALENV_DISABLE_PROMPT}" ]; then
       echo "pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior." 1>&2
     fi
     cat <<EOS
-export _OLD_VIRTUAL_PS1="\${PS1}";
-export PS1="(${venv}) \${PS1}";
+export _OLD_VIRTUAL_PS1="\${PS1:-}";
+export PS1="(${venv}) \${PS1:-}";
 EOS
     ;;
   esac

--- a/test/activate.bats
+++ b/test/activate.bats
@@ -34,8 +34,8 @@ deactivated
 export PYENV_VIRTUAL_ENV="${PYENV_ROOT}/versions/venv";
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
-export _OLD_VIRTUAL_PS1="\${PS1}";
-export PS1="(venv) \${PS1}";
+export _OLD_VIRTUAL_PS1="\${PS1:-}";
+export PS1="(venv) \${PS1:-}";
 EOS
 
   unstub pyenv-version-name
@@ -59,8 +59,8 @@ EOS
 deactivated
 export PYENV_VIRTUAL_ENV="${PYENV_ROOT}/versions/venv";
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv";
-export _OLD_VIRTUAL_PS1="\${PS1}";
-export PS1="(venv) \${PS1}";
+export _OLD_VIRTUAL_PS1="\${PS1:-}";
+export PS1="(venv) \${PS1:-}";
 EOS
 
   unstub pyenv-version-name
@@ -87,8 +87,8 @@ pyenv-virtualenv: activate venv
 export PYENV_VIRTUAL_ENV="${PYENV_ROOT}/versions/venv";
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
-export _OLD_VIRTUAL_PS1="\${PS1}";
-export PS1="(venv) \${PS1}";
+export _OLD_VIRTUAL_PS1="\${PS1:-}";
+export PS1="(venv) \${PS1:-}";
 EOS
 
   unstub pyenv-version-name
@@ -115,8 +115,8 @@ export PYENV_ACTIVATE_SHELL=1;
 export PYENV_VIRTUAL_ENV="${PYENV_ROOT}/versions/venv";
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
-export _OLD_VIRTUAL_PS1="\${PS1}";
-export PS1="(venv) \${PS1}";
+export _OLD_VIRTUAL_PS1="\${PS1:-}";
+export PS1="(venv) \${PS1:-}";
 EOS
 
   unstub pyenv-version-name
@@ -192,8 +192,8 @@ export PYENV_ACTIVATE_SHELL=1;
 export PYENV_VIRTUAL_ENV="${PYENV_ROOT}/versions/venv27";
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv27";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
-export _OLD_VIRTUAL_PS1="\${PS1}";
-export PS1="(venv27) \${PS1}";
+export _OLD_VIRTUAL_PS1="\${PS1:-}";
+export PS1="(venv27) \${PS1:-}";
 EOS
 
   unstub pyenv-virtualenv-prefix
@@ -218,8 +218,8 @@ export PYENV_ACTIVATE_SHELL=1;
 export PYENV_VIRTUAL_ENV="${PYENV_ROOT}/versions/venv27";
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv27";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
-export _OLD_VIRTUAL_PS1="\${PS1}";
-export PS1="(venv27) \${PS1}";
+export _OLD_VIRTUAL_PS1="\${PS1:-}";
+export PS1="(venv27) \${PS1:-}";
 EOS
 
   unstub pyenv-virtualenv-prefix
@@ -391,8 +391,8 @@ export PYENV_ACTIVATE_SHELL=1;
 export PYENV_VIRTUAL_ENV="${PYENV_ROOT}/versions/venv27";
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv27";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
-export _OLD_VIRTUAL_PS1="\${PS1}";
-export PS1="(venv27) \${PS1}";
+export _OLD_VIRTUAL_PS1="\${PS1:-}";
+export PS1="(venv27) \${PS1:-}";
 EOS
 
   unstub pyenv-sh-deactivate

--- a/test/conda-activate.bats
+++ b/test/conda-activate.bats
@@ -37,8 +37,8 @@ export PYENV_VIRTUAL_ENV="${PYENV_ROOT}/versions/anaconda-2.3.0";
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/anaconda-2.3.0";
 export CONDA_DEFAULT_ENV="root";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
-export _OLD_VIRTUAL_PS1="\${PS1}";
-export PS1="(anaconda-2.3.0) \${PS1}";
+export _OLD_VIRTUAL_PS1="\${PS1:-}";
+export PS1="(anaconda-2.3.0) \${PS1:-}";
 export CONDA_PREFIX="${TMP}/pyenv/versions/anaconda-2.3.0";
 EOS
 
@@ -96,8 +96,8 @@ export PYENV_VIRTUAL_ENV="${PYENV_ROOT}/versions/miniconda-3.9.1";
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/miniconda-3.9.1";
 export CONDA_DEFAULT_ENV="root";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
-export _OLD_VIRTUAL_PS1="\${PS1}";
-export PS1="(miniconda-3.9.1) \${PS1}";
+export _OLD_VIRTUAL_PS1="\${PS1:-}";
+export PS1="(miniconda-3.9.1) \${PS1:-}";
 export CONDA_PREFIX="${TMP}/pyenv/versions/miniconda-3.9.1";
 EOS
 
@@ -126,8 +126,8 @@ export PYENV_VIRTUAL_ENV="${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo";
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo";
 export CONDA_DEFAULT_ENV="foo";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
-export _OLD_VIRTUAL_PS1="\${PS1}";
-export PS1="(anaconda-2.3.0/envs/foo) \${PS1}";
+export _OLD_VIRTUAL_PS1="\${PS1:-}";
+export PS1="(anaconda-2.3.0/envs/foo) \${PS1:-}";
 export CONDA_PREFIX="${TMP}/pyenv/versions/anaconda-2.3.0/envs/foo";
 . "${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo/etc/conda/activate.d/activate.sh";
 EOS
@@ -159,8 +159,8 @@ export PYENV_VIRTUAL_ENV="${PYENV_ROOT}/versions/miniconda-3.9.1/envs/bar";
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/miniconda-3.9.1/envs/bar";
 export CONDA_DEFAULT_ENV="bar";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
-export _OLD_VIRTUAL_PS1="\${PS1}";
-export PS1="(miniconda-3.9.1/envs/bar) \${PS1}";
+export _OLD_VIRTUAL_PS1="\${PS1:-}";
+export PS1="(miniconda-3.9.1/envs/bar) \${PS1:-}";
 export CONDA_PREFIX="${TMP}/pyenv/versions/miniconda-3.9.1/envs/bar";
 . "${PYENV_ROOT}/versions/miniconda-3.9.1/envs/bar/etc/conda/activate.d/activate.sh";
 EOS

--- a/test/conda-deactivate.bats
+++ b/test/conda-deactivate.bats
@@ -34,15 +34,15 @@ unset CONDA_PREFIX
 unset PYENV_VIRTUAL_ENV;
 unset VIRTUAL_ENV;
 unset CONDA_DEFAULT_ENV;
-if [ -n "\${_OLD_VIRTUAL_PATH}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PATH:-}" ]; then
   export PATH="\${_OLD_VIRTUAL_PATH}";
   unset _OLD_VIRTUAL_PATH;
 fi;
-if [ -n "\${_OLD_VIRTUAL_PYTHONHOME}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PYTHONHOME:-}" ]; then
   export PYTHONHOME="\${_OLD_VIRTUAL_PYTHONHOME}";
   unset _OLD_VIRTUAL_PYTHONHOME;
 fi;
-if [ -n "\${_OLD_VIRTUAL_PS1}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PS1:-}" ]; then
   export PS1="\${_OLD_VIRTUAL_PS1}";
   unset _OLD_VIRTUAL_PS1;
 fi;
@@ -102,15 +102,15 @@ unset CONDA_PREFIX
 unset PYENV_VIRTUAL_ENV;
 unset VIRTUAL_ENV;
 unset CONDA_DEFAULT_ENV;
-if [ -n "\${_OLD_VIRTUAL_PATH}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PATH:-}" ]; then
   export PATH="\${_OLD_VIRTUAL_PATH}";
   unset _OLD_VIRTUAL_PATH;
 fi;
-if [ -n "\${_OLD_VIRTUAL_PYTHONHOME}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PYTHONHOME:-}" ]; then
   export PYTHONHOME="\${_OLD_VIRTUAL_PYTHONHOME}";
   unset _OLD_VIRTUAL_PYTHONHOME;
 fi;
-if [ -n "\${_OLD_VIRTUAL_PS1}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PS1:-}" ]; then
   export PS1="\${_OLD_VIRTUAL_PS1}";
   unset _OLD_VIRTUAL_PS1;
 fi;

--- a/test/deactivate.bats
+++ b/test/deactivate.bats
@@ -30,15 +30,15 @@ setup() {
   assert_output <<EOS
 unset PYENV_VIRTUAL_ENV;
 unset VIRTUAL_ENV;
-if [ -n "\${_OLD_VIRTUAL_PATH}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PATH:-}" ]; then
   export PATH="\${_OLD_VIRTUAL_PATH}";
   unset _OLD_VIRTUAL_PATH;
 fi;
-if [ -n "\${_OLD_VIRTUAL_PYTHONHOME}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PYTHONHOME:-}" ]; then
   export PYTHONHOME="\${_OLD_VIRTUAL_PYTHONHOME}";
   unset _OLD_VIRTUAL_PYTHONHOME;
 fi;
-if [ -n "\${_OLD_VIRTUAL_PS1}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PS1:-}" ]; then
   export PS1="\${_OLD_VIRTUAL_PS1}";
   unset _OLD_VIRTUAL_PS1;
 fi;
@@ -60,15 +60,15 @@ EOS
   assert_output <<EOS
 unset PYENV_VIRTUAL_ENV;
 unset VIRTUAL_ENV;
-if [ -n "\${_OLD_VIRTUAL_PATH}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PATH:-}" ]; then
   export PATH="\${_OLD_VIRTUAL_PATH}";
   unset _OLD_VIRTUAL_PATH;
 fi;
-if [ -n "\${_OLD_VIRTUAL_PYTHONHOME}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PYTHONHOME:-}" ]; then
   export PYTHONHOME="\${_OLD_VIRTUAL_PYTHONHOME}";
   unset _OLD_VIRTUAL_PYTHONHOME;
 fi;
-if [ -n "\${_OLD_VIRTUAL_PS1}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PS1:-}" ]; then
   export PS1="\${_OLD_VIRTUAL_PS1}";
   unset _OLD_VIRTUAL_PS1;
 fi;
@@ -92,15 +92,15 @@ EOS
 pyenv-virtualenv: deactivate venv
 unset PYENV_VIRTUAL_ENV;
 unset VIRTUAL_ENV;
-if [ -n "\${_OLD_VIRTUAL_PATH}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PATH:-}" ]; then
   export PATH="\${_OLD_VIRTUAL_PATH}";
   unset _OLD_VIRTUAL_PATH;
 fi;
-if [ -n "\${_OLD_VIRTUAL_PYTHONHOME}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PYTHONHOME:-}" ]; then
   export PYTHONHOME="\${_OLD_VIRTUAL_PYTHONHOME}";
   unset _OLD_VIRTUAL_PYTHONHOME;
 fi;
-if [ -n "\${_OLD_VIRTUAL_PS1}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PS1:-}" ]; then
   export PS1="\${_OLD_VIRTUAL_PS1}";
   unset _OLD_VIRTUAL_PS1;
 fi;
@@ -122,15 +122,15 @@ EOS
   assert_output <<EOS
 unset PYENV_VIRTUAL_ENV;
 unset VIRTUAL_ENV;
-if [ -n "\${_OLD_VIRTUAL_PATH}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PATH:-}" ]; then
   export PATH="\${_OLD_VIRTUAL_PATH}";
   unset _OLD_VIRTUAL_PATH;
 fi;
-if [ -n "\${_OLD_VIRTUAL_PYTHONHOME}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PYTHONHOME:-}" ]; then
   export PYTHONHOME="\${_OLD_VIRTUAL_PYTHONHOME}";
   unset _OLD_VIRTUAL_PYTHONHOME;
 fi;
-if [ -n "\${_OLD_VIRTUAL_PS1}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PS1:-}" ]; then
   export PS1="\${_OLD_VIRTUAL_PS1}";
   unset _OLD_VIRTUAL_PS1;
 fi;
@@ -154,15 +154,15 @@ unset PYENV_VERSION;
 unset PYENV_ACTIVATE_SHELL;
 unset PYENV_VIRTUAL_ENV;
 unset VIRTUAL_ENV;
-if [ -n "\${_OLD_VIRTUAL_PATH}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PATH:-}" ]; then
   export PATH="\${_OLD_VIRTUAL_PATH}";
   unset _OLD_VIRTUAL_PATH;
 fi;
-if [ -n "\${_OLD_VIRTUAL_PYTHONHOME}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PYTHONHOME:-}" ]; then
   export PYTHONHOME="\${_OLD_VIRTUAL_PYTHONHOME}";
   unset _OLD_VIRTUAL_PYTHONHOME;
 fi;
-if [ -n "\${_OLD_VIRTUAL_PS1}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PS1:-}" ]; then
   export PS1="\${_OLD_VIRTUAL_PS1}";
   unset _OLD_VIRTUAL_PS1;
 fi;
@@ -186,15 +186,15 @@ unset PYENV_VERSION;
 unset PYENV_ACTIVATE_SHELL;
 unset PYENV_VIRTUAL_ENV;
 unset VIRTUAL_ENV;
-if [ -n "\${_OLD_VIRTUAL_PATH}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PATH:-}" ]; then
   export PATH="\${_OLD_VIRTUAL_PATH}";
   unset _OLD_VIRTUAL_PATH;
 fi;
-if [ -n "\${_OLD_VIRTUAL_PYTHONHOME}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PYTHONHOME:-}" ]; then
   export PYTHONHOME="\${_OLD_VIRTUAL_PYTHONHOME}";
   unset _OLD_VIRTUAL_PYTHONHOME;
 fi;
-if [ -n "\${_OLD_VIRTUAL_PS1}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PS1:-}" ]; then
   export PS1="\${_OLD_VIRTUAL_PS1}";
   unset _OLD_VIRTUAL_PS1;
 fi;
@@ -216,15 +216,15 @@ EOS
   assert_output <<EOS
 unset PYENV_VIRTUAL_ENV;
 unset VIRTUAL_ENV;
-if [ -n "\${_OLD_VIRTUAL_PATH}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PATH:-}" ]; then
   export PATH="\${_OLD_VIRTUAL_PATH}";
   unset _OLD_VIRTUAL_PATH;
 fi;
-if [ -n "\${_OLD_VIRTUAL_PYTHONHOME}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PYTHONHOME:-}" ]; then
   export PYTHONHOME="\${_OLD_VIRTUAL_PYTHONHOME}";
   unset _OLD_VIRTUAL_PYTHONHOME;
 fi;
-if [ -n "\${_OLD_VIRTUAL_PS1}" ]; then
+if [ -n "\${_OLD_VIRTUAL_PS1:-}" ]; then
   export PS1="\${_OLD_VIRTUAL_PS1}";
   unset _OLD_VIRTUAL_PS1;
 fi;


### PR DESCRIPTION
This fixes the case of `bash: PS1: unbound variable` when `PYENV_VIRTUALENV_DISABLE_PROMPT` isn't set.
This should have been part of #423, sorry for that. I also fixed the tests related to virtualenv activation/deactivation which were failing due to my changes.