### PR TITLE
Update `get-pip.py` URLs in `pyenv-virtualenv`

### DIFF
--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -485,7 +485,7 @@ if [ -z "${GET_PIP_URL}" ]; then
       GET_PIP_URL="https://bootstrap.pypa.io/pip/2.7/get-pip.py"
       ;;
     3.2 | 3.2.* )
-      GET_PIP_URL="https://bootstrap.pypa.io/3.2/get-pip.py"
+      GET_PIP_URL="https://bootstrap.pypa.io/pip/3.2/get-pip.py"
       ;;
     3.3 | 3.3.* )
       GET_PIP_URL="https://bootstrap.pypa.io/3.3/get-pip.py"

--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -496,6 +496,9 @@ if [ -z "${GET_PIP_URL}" ]; then
     3.5 | 3.5.* )
       GET_PIP_URL="https://bootstrap.pypa.io/pip/3.5/get-pip.py"
       ;;
+    3.6 | 3.6.* )
+      GET_PIP_URL="https://bootstrap.pypa.io/pip/3.6/get-pip.py"
+      ;;
     * )
       GET_PIP_URL="https://bootstrap.pypa.io/get-pip.py"
       ;;

--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -488,7 +488,7 @@ if [ -z "${GET_PIP_URL}" ]; then
       GET_PIP_URL="https://bootstrap.pypa.io/pip/3.2/get-pip.py"
       ;;
     3.3 | 3.3.* )
-      GET_PIP_URL="https://bootstrap.pypa.io/3.3/get-pip.py"
+      GET_PIP_URL="https://bootstrap.pypa.io/pip/3.3/get-pip.py"
       ;;
     * )
       GET_PIP_URL="https://bootstrap.pypa.io/get-pip.py"

--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -493,6 +493,9 @@ if [ -z "${GET_PIP_URL}" ]; then
     3.4 | 3.4.* )
       GET_PIP_URL="https://bootstrap.pypa.io/pip/3.4/get-pip.py"
       ;;
+    3.5 | 3.5.* )
+      GET_PIP_URL="https://bootstrap.pypa.io/pip/3.5/get-pip.py"
+      ;;
     * )
       GET_PIP_URL="https://bootstrap.pypa.io/get-pip.py"
       ;;

--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -500,7 +500,7 @@ if [ -z "${GET_PIP_URL}" ]; then
       GET_PIP_URL="https://bootstrap.pypa.io/pip/3.6/get-pip.py"
       ;;
     * )
-      GET_PIP_URL="https://bootstrap.pypa.io/get-pip.py"
+      GET_PIP_URL="https://bootstrap.pypa.io/pip/get-pip.py"
       ;;
     esac
   fi

--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -490,6 +490,9 @@ if [ -z "${GET_PIP_URL}" ]; then
     3.3 | 3.3.* )
       GET_PIP_URL="https://bootstrap.pypa.io/pip/3.3/get-pip.py"
       ;;
+    3.4 | 3.4.* )
+      GET_PIP_URL="https://bootstrap.pypa.io/pip/3.4/get-pip.py"
+      ;;
     * )
       GET_PIP_URL="https://bootstrap.pypa.io/get-pip.py"
       ;;


### PR DESCRIPTION
This pull request is based on the work in #419 but includes updates for all `get-pip.py` URLs located at https://bootstrap.pypa.io/pip/.