### PR TITLE
Upgrade uninstall hook after pyenv/pyenv#2432

### DIFF
--- a/etc/pyenv.d/uninstall/envs.bash
+++ b/etc/pyenv.d/uninstall/envs.bash
@@ -2,29 +2,33 @@ resolve_link() {
   $(type -p greadlink readlink | head -1) "$1"
 }
 
-if [ -n "${DEFINITION}" ]; then
-  if [[ "${DEFINITION}" != "${DEFINITION%/envs/*}" ]]; then
-    # Uninstall virtualenv by long name
-    exec pyenv-virtualenv-delete ${FORCE+-f} "${DEFINITION}"
-    exit 128
-  else
-    VERSION_NAME="${VERSION_NAME:-${DEFINITION##*/}}"
-    PREFIX="${PREFIX:-${PYENV_ROOT}/versions/${VERSION_NAME}}"
-    if [ -L "${PREFIX}" ]; then
-      REAL_PREFIX="$(resolve_link "${PREFIX}" 2>/dev/null || true)"
-      REAL_DEFINITION="${REAL_PREFIX#${PYENV_ROOT}/versions/}"
-      if [[ "${REAL_DEFINITION}" != "${REAL_DEFINITION%/envs/*}" ]]; then
-        # Uninstall virtualenv by short name
-        exec pyenv-virtualenv-delete ${FORCE+-f} "${REAL_DEFINITION}"
-        exit 128
-      fi
+uninstall_related_virtual_env() {
+  if [ -n "${DEFINITION}" ]; then
+    if [[ "${DEFINITION}" != "${DEFINITION%/envs/*}" ]]; then
+      # Uninstall virtualenv by long name
+      exec pyenv-virtualenv-delete ${FORCE+-f} "${DEFINITION}"
+      exit 128
     else
-      # Uninstall all virtualenvs inside `envs` directory too
-      shopt -s nullglob
-      for virtualenv in "${PREFIX}/envs/"*; do
-        pyenv-virtualenv-delete ${FORCE+-f} "${DEFINITION}/envs/${virtualenv##*/}"
-      done
-      shopt -u nullglob
+      VERSION_NAME="${VERSION_NAME:-${DEFINITION##*/}}"
+      PREFIX="${PREFIX:-${PYENV_ROOT}/versions/${VERSION_NAME}}"
+      if [ -L "${PREFIX}" ]; then
+        REAL_PREFIX="$(resolve_link "${PREFIX}" 2>/dev/null || true)"
+        REAL_DEFINITION="${REAL_PREFIX#${PYENV_ROOT}/versions/}"
+        if [[ "${REAL_DEFINITION}" != "${REAL_DEFINITION%/envs/*}" ]]; then
+          # Uninstall virtualenv by short name
+          exec pyenv-virtualenv-delete ${FORCE+-f} "${REAL_DEFINITION}"
+          exit 128
+        fi
+      else
+        # Uninstall all virtualenvs inside `envs` directory too
+        shopt -s nullglob
+        for virtualenv in "${PREFIX}/envs/"*; do
+          pyenv-virtualenv-delete ${FORCE+-f} "${DEFINITION}/envs/${virtualenv##*/}"
+        done
+        shopt -u nullglob
+      fi
     fi
   fi
-fi
+}
+
+before_uninstall "uninstall_related_virtual_env"


### PR DESCRIPTION
Found only the link is uninstalled by `pyenv unisntall` but not the original env. It turns out that the bug is related with pyenv/pyenv#2432.

Here's a fix that refactor the code to register itself as a hook explicitly and let the hook called by `pyenv uninstall` for multiple versions.