### PR TITLE
Update PYENV_VIRTUALENV_VERSION

### DIFF
--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -13,7 +13,7 @@
 #   -u/--upgrade     Imply --force
 #
 
-PYENV_VIRTUALENV_VERSION="1.1.5"
+PYENV_VIRTUALENV_VERSION="1.2.1"
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x


### PR DESCRIPTION
Following the latest couple of releases (see #443), it looks like the version number needs to be updated inside the repo for `pyenv virtualenv --version` to report correctly.