### PR TITLE
More helpful error message

### DIFF
--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -336,19 +336,20 @@ fi
 # Set VERSION_NAME as default version in this script
 export PYENV_VERSION="${VERSION_NAME}"
 
-is_available() {
-  python-build --definitions | grep -F -x -q "$1"
+not_installed_message() {
+    local is_available=$(python-build --definitions | grep -F -x "$1")
+    echo "pyenv-virtualenv: \`${1}' is not installed in pyenv." 1>&2
+    if [[ $is_available ]]; then
+        echo "Run \`pyenv install ${1}' to install it." 1>&2
+    else
+        echo "It does not look like a valid Python version. See \`pyenv install --list' for available versions." 1>&2
+    fi
 }
 
 # Source version must exist before creating virtualenv.
 PREFIX="$(pyenv-prefix 2>/dev/null || true)"
 if [ ! -d "${PREFIX}" ]; then
-  echo "pyenv-virtualenv: \`${PYENV_VERSION}' is not installed in pyenv." 1>&2
-  if is_available "${PYENV_VERSION}"; then
-    echo "Run \`pyenv install ${PYENV_VERSION}' to install it." 1>&2
-  else
-    echo "It also does not look like a valid Python version. See \`pyenv install --list' for available versions." 1>&2
-  fi
+  not_installed_message "${PYENV_VERSION}"
   exit 1
 fi
 
@@ -450,7 +451,8 @@ else
           if [ -x "${python}" ]; then
             VIRTUALENV_OPTIONS[${#VIRTUALENV_OPTIONS[*]}]="--python=${python}"
           else
-            echo "pyenv-virtualenv: \`${VIRTUALENV_PYTHON##*/}' is not installed in pyenv." 1>&2
+            # echo "pyenv-virtualenv: \`${VIRTUALENV_PYTHON##*/}' is not installed in pyenv." 1>&2
+            not_installed_message "${VIRTUALENV_PYTHON##*/}"
             exit 1
           fi
         fi

--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -340,6 +340,8 @@ export PYENV_VERSION="${VERSION_NAME}"
 PREFIX="$(pyenv-prefix 2>/dev/null || true)"
 if [ ! -d "${PREFIX}" ]; then
   echo "pyenv-virtualenv: \`${PYENV_VERSION}' is not installed in pyenv." 1>&2
+  echo
+  echo "See all available versions with \`pyenv install --list'."
   exit 1
 fi
 

--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -337,7 +337,7 @@ fi
 export PYENV_VERSION="${VERSION_NAME}"
 
 is_available() {
-  python-build --definitions | $(type -P ggrep grep | head -1) -F -x "$1" >/dev/null
+  python-build --definitions | grep -F -x -q "$1"
 }
 
 # Source version must exist before creating virtualenv.

--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -336,12 +336,19 @@ fi
 # Set VERSION_NAME as default version in this script
 export PYENV_VERSION="${VERSION_NAME}"
 
+is_available() {
+  python-build --definitions | $(type -P ggrep grep | head -1) -F -x "$1" >/dev/null
+}
+
 # Source version must exist before creating virtualenv.
 PREFIX="$(pyenv-prefix 2>/dev/null || true)"
 if [ ! -d "${PREFIX}" ]; then
   echo "pyenv-virtualenv: \`${PYENV_VERSION}' is not installed in pyenv." 1>&2
-  echo
-  echo "See all available versions with \`pyenv install --list'."
+  if is_available "${PYENV_VERSION}"; then
+    echo "Run \`pyenv install ${PYENV_VERSION}' to install it." 1>&2
+  else
+    echo "It also does not look like a valid Python version. See \`pyenv install --list' for available versions." 1>&2
+  fi
   exit 1
 fi
 

--- a/test/python.bats
+++ b/test/python.bats
@@ -14,6 +14,7 @@ setup() {
   stub pyenv-rehash " : true"
   stub pyenv-version-name "echo \${PYENV_VERSION}"
   stub curl true
+  stub python-build "echo python2.7"
 }
 
 teardown() {
@@ -22,6 +23,7 @@ teardown() {
   unstub pyenv-prefix
   unstub pyenv-hooks
   unstub pyenv-rehash
+  unstub python-build
   teardown_version "2.7.8"
   rm -fr "$TMP"/*
 }
@@ -96,6 +98,7 @@ OUT
 
   assert_output <<OUT
 pyenv-virtualenv: \`python2.7' is not installed in pyenv.
+Run \`pyenv install python2.7' to install it.
 OUT
   assert_failure
 
@@ -105,4 +108,14 @@ OUT
   remove_executable "2.7.7" "python2.7"
   remove_executable "2.7.8" "python2.7"
   remove_executable "2.7.9" "python2.7"
+}
+
+@test "invalid python name" {
+  run pyenv-virtualenv --verbose --python=99.99.99 venv
+
+  assert_output <<OUT
+pyenv-virtualenv: \`99.99.99' is not installed in pyenv.
+It does not look like a valid Python version. See \`pyenv install --list' for available versions.
+OUT
+  assert_failure
 }


### PR DESCRIPTION
Added a more helpful error message for when you're trying to create a virtual environment with python version which is not installed. As a user i keep running into this: i want to make a particular vent but i don't have the python and i have 

If I try to install a non-existent python with peen I get something like that:

```
python-build: definition not found: 3.9.99

See all available versions with `pyenv install --list'.

If the version you need is missing, try upgrading pyenv.
```

with a possibility of getting even more help by listing all the candidates which contain the version passed and trying to be helpful as to how to upgrade pyenv (implementation form 2.3.17 ca be seen [here](https://github.com/pyenv/pyenv/blob/9a4f9c2511f39701cb8e3af1e6809be28210c3b9/plugins/python-build/bin/pyenv-install#L256). This is a bit much to do here so I've just added the 'See all available versions...' line.
