### PR TITLE
Non blocking fish prompt

### DIFF
--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -104,7 +104,7 @@ esac
 case "$shell" in
 fish )
   cat <<EOS
-function _pyenv_virtualenv_hook --on-event fish_prompt;
+function _pyenv_virtualenv_hook --on-event fish_preexec;
   set -l ret \$status
   if [ -n "\$VIRTUAL_ENV" ]
     pyenv activate --quiet; or pyenv deactivate --quiet; or true


### PR DESCRIPTION
I propose this as a less intrusive alternative to #451. This can be dropped in as a stop gap to ease some frustration for fish users. I think the philosophy in #451 is a better approach if we can figure out all the difficult bits.

This PR will make pyenv run before the command executes and won't block the prompt from showing, which feels a lot better to use.

See also #338