### PR TITLE
Bump pyenv-virtualenv reporting version to match release

### DIFF
--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -13,7 +13,7 @@
 #   -u/--upgrade     Imply --force
 #
 
-PYENV_VIRTUALENV_VERSION="1.2.1"
+PYENV_VIRTUALENV_VERSION="1.2.2"
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x


### PR DESCRIPTION
The latest release so far (Dec 2023) is 1.2.2, but the version reported is still 1.2.1:
https://github.com/pyenv/pyenv-virtualenv/releases/tag/v1.2.2

Fix #464 #465 

Related #449 