### PR TITLE
Fix fish prompt

### DIFF
--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -246,11 +246,17 @@ if [ -z "${PYENV_VIRTUALENV_DISABLE_PROMPT}" ]; then
   fish )
     if [ -z "${QUIET}" ]; then
       cat <<EOS
-      functions -e _pyenv_old_prompt
-      functions -c fish_prompt _pyenv_old_prompt
+      functions -e _pyenv_old_prompt              # remove old prompt function if exists. 
+                                                  # since everything is in memory, it's safe to
+                                                  # remove it.
+      functions -c fish_prompt _pyenv_old_prompt  # backup old prompt function
+
+      # from python-venv
       function fish_prompt
-          echo -n "(${venv}) "
-          _pyenv_old_prompt
+          set -l prompt (_pyenv_old_prompt)       # call old prompt function first since it might 
+                                                  # read exit status
+          echo -n "(${venv}) "                    # add virtualenv to prompt
+          string join -- \n \$prompt              # handle multiline prompts
       end
 EOS
     fi

--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -245,7 +245,14 @@ if [ -z "${PYENV_VIRTUALENV_DISABLE_PROMPT}" ]; then
   case "${shell}" in
   fish )
     if [ -z "${QUIET}" ]; then
-      echo "pyenv-virtualenv: prompt changing not working for fish." 1>&2
+      cat <<EOS
+      functions -e _pyenv_old_prompt
+      functions -c fish_prompt _pyenv_old_prompt
+      function fish_prompt
+          echo -n "(${venv}) "
+          _pyenv_old_prompt
+      end
+EOS
     fi
     ;;
   * )

--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -246,18 +246,18 @@ if [ -z "${PYENV_VIRTUALENV_DISABLE_PROMPT}" ]; then
   fish )
     if [ -z "${QUIET}" ]; then
       cat <<EOS
-      functions -e _pyenv_old_prompt              # remove old prompt function if exists. 
-                                                  # since everything is in memory, it's safe to
-                                                  # remove it.
-      functions -c fish_prompt _pyenv_old_prompt  # backup old prompt function
+functions -e _pyenv_old_prompt              # remove old prompt function if exists. 
+                                            # since everything is in memory, it's safe to
+                                            # remove it.
+functions -c fish_prompt _pyenv_old_prompt  # backup old prompt function
 
-      # from python-venv
-      function fish_prompt
-          set -l prompt (_pyenv_old_prompt)       # call old prompt function first since it might 
-                                                  # read exit status
-          echo -n "(${venv}) "                    # add virtualenv to prompt
-          string join -- \n \$prompt              # handle multiline prompts
-      end
+# from python-venv
+function fish_prompt
+    set -l prompt (_pyenv_old_prompt)       # call old prompt function first since it might 
+                                            # read exit status
+    echo -n "(${venv}) "                    # add virtualenv to prompt
+    string join -- \n \$prompt              # handle multiline prompts
+end
 EOS
     fi
     ;;

--- a/bin/pyenv-sh-deactivate
+++ b/bin/pyenv-sh-deactivate
@@ -187,7 +187,13 @@ esac
 
 case "${shell}" in
 fish )
-  :
+  cat <<EOS
+  if functions -q _pyenv_old_prompt
+    functions -e fish_prompt
+    functions -c _pyenv_old_prompt fish_prompt
+    functions -e _pyenv_old_prompt
+  end
+EOS
   ;;
 * )
   cat <<EOS

--- a/bin/pyenv-sh-deactivate
+++ b/bin/pyenv-sh-deactivate
@@ -188,13 +188,13 @@ esac
 case "${shell}" in
 fish )
   cat <<EOS
-  # check if old prompt function exists
-  if functions -q _pyenv_old_prompt
-    # remove old prompt function if exists.
-    functions -e fish_prompt
-    functions -c _pyenv_old_prompt fish_prompt
-    functions -e _pyenv_old_prompt
-  end
+# check if old prompt function exists
+if functions -q _pyenv_old_prompt
+  # remove old prompt function if exists.
+  functions -e fish_prompt
+  functions -c _pyenv_old_prompt fish_prompt
+  functions -e _pyenv_old_prompt
+end
 EOS
   ;;
 * )

--- a/bin/pyenv-sh-deactivate
+++ b/bin/pyenv-sh-deactivate
@@ -188,7 +188,9 @@ esac
 case "${shell}" in
 fish )
   cat <<EOS
+  # check if old prompt function exists
   if functions -q _pyenv_old_prompt
+    # remove old prompt function if exists.
     functions -e fish_prompt
     functions -c _pyenv_old_prompt fish_prompt
     functions -e _pyenv_old_prompt

--- a/test/activate.bats
+++ b/test/activate.bats
@@ -138,7 +138,18 @@ EOS
 deactivated
 set -gx PYENV_VIRTUAL_ENV "${PYENV_ROOT}/versions/venv";
 set -gx VIRTUAL_ENV "${PYENV_ROOT}/versions/venv";
-pyenv-virtualenv: prompt changing not working for fish.
+functions -e _pyenv_old_prompt              # remove old prompt function if exists. 
+                                            # since everything is in memory, it's safe to
+                                            # remove it.
+functions -c fish_prompt _pyenv_old_prompt  # backup old prompt function
+
+# from python-venv
+function fish_prompt
+    set -l prompt (_pyenv_old_prompt)       # call old prompt function first since it might 
+                                            # read exit status
+    echo -n "(venv) "                    # add virtualenv to prompt
+    string join -- \n \$prompt              # handle multiline prompts
+end
 EOS
 
   unstub pyenv-version-name
@@ -164,7 +175,18 @@ set -gx PYENV_VERSION "venv";
 set -gx PYENV_ACTIVATE_SHELL 1;
 set -gx PYENV_VIRTUAL_ENV "${PYENV_ROOT}/versions/venv";
 set -gx VIRTUAL_ENV "${PYENV_ROOT}/versions/venv";
-pyenv-virtualenv: prompt changing not working for fish.
+functions -e _pyenv_old_prompt              # remove old prompt function if exists. 
+                                            # since everything is in memory, it's safe to
+                                            # remove it.
+functions -c fish_prompt _pyenv_old_prompt  # backup old prompt function
+
+# from python-venv
+function fish_prompt
+    set -l prompt (_pyenv_old_prompt)       # call old prompt function first since it might 
+                                            # read exit status
+    echo -n "(venv) "                    # add virtualenv to prompt
+    string join -- \n \$prompt              # handle multiline prompts
+end
 EOS
 
   unstub pyenv-version-name
@@ -239,7 +261,18 @@ set -gx PYENV_VERSION "venv27";
 set -gx PYENV_ACTIVATE_SHELL 1;
 set -gx PYENV_VIRTUAL_ENV "${PYENV_ROOT}/versions/venv27";
 set -gx VIRTUAL_ENV "${PYENV_ROOT}/versions/venv27";
-pyenv-virtualenv: prompt changing not working for fish.
+functions -e _pyenv_old_prompt              # remove old prompt function if exists. 
+                                            # since everything is in memory, it's safe to
+                                            # remove it.
+functions -c fish_prompt _pyenv_old_prompt  # backup old prompt function
+
+# from python-venv
+function fish_prompt
+    set -l prompt (_pyenv_old_prompt)       # call old prompt function first since it might 
+                                            # read exit status
+    echo -n "(venv27) "                    # add virtualenv to prompt
+    string join -- \n \$prompt              # handle multiline prompts
+end
 EOS
 
   unstub pyenv-virtualenv-prefix
@@ -263,7 +296,18 @@ set -gx PYENV_VERSION "venv27";
 set -gx PYENV_ACTIVATE_SHELL 1;
 set -gx PYENV_VIRTUAL_ENV "${PYENV_ROOT}/versions/venv27";
 set -gx VIRTUAL_ENV "${PYENV_ROOT}/versions/venv27";
-pyenv-virtualenv: prompt changing not working for fish.
+functions -e _pyenv_old_prompt              # remove old prompt function if exists. 
+                                            # since everything is in memory, it's safe to
+                                            # remove it.
+functions -c fish_prompt _pyenv_old_prompt  # backup old prompt function
+
+# from python-venv
+function fish_prompt
+    set -l prompt (_pyenv_old_prompt)       # call old prompt function first since it might 
+                                            # read exit status
+    echo -n "(venv27) "                    # add virtualenv to prompt
+    string join -- \n \$prompt              # handle multiline prompts
+end
 EOS
 
   unstub pyenv-virtualenv-prefix

--- a/test/conda-activate.bats
+++ b/test/conda-activate.bats
@@ -70,7 +70,18 @@ deactivated
 set -gx PYENV_VIRTUAL_ENV "${TMP}/pyenv/versions/anaconda-2.3.0";
 set -gx VIRTUAL_ENV "${TMP}/pyenv/versions/anaconda-2.3.0";
 set -gx CONDA_DEFAULT_ENV "root";
-pyenv-virtualenv: prompt changing not working for fish.
+functions -e _pyenv_old_prompt              # remove old prompt function if exists. 
+                                            # since everything is in memory, it's safe to
+                                            # remove it.
+functions -c fish_prompt _pyenv_old_prompt  # backup old prompt function
+
+# from python-venv
+function fish_prompt
+    set -l prompt (_pyenv_old_prompt)       # call old prompt function first since it might 
+                                            # read exit status
+    echo -n "(anaconda-2.3.0) "                    # add virtualenv to prompt
+    string join -- \n \$prompt              # handle multiline prompts
+end
 EOS
 
   unstub pyenv-version-name

--- a/test/conda-deactivate.bats
+++ b/test/conda-deactivate.bats
@@ -82,6 +82,13 @@ if [ -n "\$_OLD_VIRTUAL_PYTHONHOME" ];
   set -gx PYTHONHOME "\$_OLD_VIRTUAL_PYTHONHOME";
   set -e _OLD_VIRTUAL_PYTHONHOME;
 end;
+# check if old prompt function exists
+if functions -q _pyenv_old_prompt
+  # remove old prompt function if exists.
+  functions -e fish_prompt
+  functions -c _pyenv_old_prompt fish_prompt
+  functions -e _pyenv_old_prompt
+end
 if functions -q deactivate;
   functions -e deactivate;
 end;

--- a/test/deactivate.bats
+++ b/test/deactivate.bats
@@ -225,6 +225,13 @@ if [ -n "\$_OLD_VIRTUAL_PYTHONHOME" ];
   set -gx PYTHONHOME "\$_OLD_VIRTUAL_PYTHONHOME";
   set -e _OLD_VIRTUAL_PYTHONHOME;
 end;
+# check if old prompt function exists
+if functions -q _pyenv_old_prompt
+  # remove old prompt function if exists.
+  functions -e fish_prompt
+  functions -c _pyenv_old_prompt fish_prompt
+  functions -e _pyenv_old_prompt
+end
 if functions -q deactivate;
   functions -e deactivate;
 end;
@@ -251,6 +258,13 @@ if [ -n "\$_OLD_VIRTUAL_PYTHONHOME" ];
   set -gx PYTHONHOME "\$_OLD_VIRTUAL_PYTHONHOME";
   set -e _OLD_VIRTUAL_PYTHONHOME;
 end;
+# check if old prompt function exists
+if functions -q _pyenv_old_prompt
+  # remove old prompt function if exists.
+  functions -e fish_prompt
+  functions -c _pyenv_old_prompt fish_prompt
+  functions -e _pyenv_old_prompt
+end
 if functions -q deactivate;
   functions -e deactivate;
 end;
@@ -279,6 +293,13 @@ if [ -n "\$_OLD_VIRTUAL_PYTHONHOME" ];
   set -gx PYTHONHOME "\$_OLD_VIRTUAL_PYTHONHOME";
   set -e _OLD_VIRTUAL_PYTHONHOME;
 end;
+# check if old prompt function exists
+if functions -q _pyenv_old_prompt
+  # remove old prompt function if exists.
+  functions -e fish_prompt
+  functions -c _pyenv_old_prompt fish_prompt
+  functions -e _pyenv_old_prompt
+end
 if functions -q deactivate;
   functions -e deactivate;
 end;
@@ -307,6 +328,13 @@ if [ -n "\$_OLD_VIRTUAL_PYTHONHOME" ];
   set -gx PYTHONHOME "\$_OLD_VIRTUAL_PYTHONHOME";
   set -e _OLD_VIRTUAL_PYTHONHOME;
 end;
+# check if old prompt function exists
+if functions -q _pyenv_old_prompt
+  # remove old prompt function if exists.
+  functions -e fish_prompt
+  functions -c _pyenv_old_prompt fish_prompt
+  functions -e _pyenv_old_prompt
+end
 if functions -q deactivate;
   functions -e deactivate;
 end;
@@ -333,6 +361,13 @@ if [ -n "\$_OLD_VIRTUAL_PYTHONHOME" ];
   set -gx PYTHONHOME "\$_OLD_VIRTUAL_PYTHONHOME";
   set -e _OLD_VIRTUAL_PYTHONHOME;
 end;
+# check if old prompt function exists
+if functions -q _pyenv_old_prompt
+  # remove old prompt function if exists.
+  functions -e fish_prompt
+  functions -c _pyenv_old_prompt fish_prompt
+  functions -e _pyenv_old_prompt
+end
 if functions -q deactivate;
   functions -e deactivate;
 end;


### PR DESCRIPTION
Hi! I use pyenv every day, and it is truly a lifesaver. The only thing that bugs me is the fact that activating a virtual environment does not change the prompt in fish. I have introduced this fix which caches the old prompt and displays a new one with the appropriate prefix. 

```sh
> pyenv virtualenv 3.12 test 
> pyenv activate test
(test) > pyenv virtualenv 3.12 test1
(test) > pyenv activate test1
(test1) > pyenv deactivate
> 
```

> Note: old prompt is cached in `_pyenv_old_prompt`. It is automatically erased during deactivation and accounted for during activation.

I hope this is useful to everyone else! Thanks for your consideration.