### PR TITLE
Add .gitattributes to prevent CRLF issues on WSL (#508)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
This PR adds a `.gitattributes` file that enforces LF line endings for shell scripts.
This resolves an issue where WSL users may encounter:

```bash
/usr/bin/env: ‘bash\r’: No such file or directory
```

This PR addresses Issue #508 

### Summary
- Ensures `.sh` scripts are checked out with LF even on Windows
- Helps WSL users avoid line-ending related execution errors