### PR TITLE
docs: add WSL note about core.autocrlf to prevent CRLF issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ From inside that directory you can:
  - Get the latest development release by running `git pull` to download the
    latest changes.
 
+💡 **WSL note:** If you're using WSL, we recommend setting Git to use Unix-style line endings to prevent script execution errors:
+
+```sh
+git config --global core.autocrlf input
+```
+
 1. **Check out pyenv-virtualenv into plugin directory**
 
     ```bash


### PR DESCRIPTION
Adds a brief note to the installation section for WSL users, recommending the use of:

```sh
git config --global core.autocrlf input
```

This prevents common CRLF-related issues (e.g., /usr/bin/env: ‘bash\r’: No such file or directory) when using pyenv-virtualenv under WSL.

The note appears right before the manual git clone instructions, where it’s most relevant for users following the README directly.

This follows up on the discussion in #509 