### PR TITLE
docs: fix the link to Pyenv shell setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ brew install --HEAD pyenv-virtualenv
 ```
 
 After installation, you'll still need to do
-[Pyenv shell setup steps](https://github.com/pyenv/pyenv#basic-github-checkout)
+[Pyenv shell setup steps](https://github.com/pyenv/pyenv#b-set-up-your-shell-environment-for-pyenv)
 then add 
 ```sh
 eval "$(pyenv virtualenv-init -)"


### PR DESCRIPTION
I believe the original page anchor was removed during a content update in the pyenv repo. This caused some inconvenience when I was setting up the pyenv-virtual plugin. I’ve replaced the link with the closest matching anchor, but I’m open to adjusting the link title to maintain consistency. 😃 